### PR TITLE
Ensure strictness in the state in modify'.

### DIFF
--- a/Control/Monad/State/Class.hs
+++ b/Control/Monad/State/Class.hs
@@ -87,7 +87,9 @@ modify f = state (\s -> ((), f s))
 -- | A variant of 'modify' in which the computation is strict in the
 -- new state.
 modify' :: MonadState s m => (s -> s) -> m ()
-modify' f = state (\s -> let s' = f s in s' `seq` ((), s'))
+modify' f = do
+  s' <- liftM f get
+  s' `seq` put s'
 
 -- | Gets specific component of the state, using a projection function
 -- supplied.


### PR DESCRIPTION
The old implementation of modify' used state f with a function f that was strict in the new state.  However, in state itself, f is applied to the state in a non-strict way, so the strictness is lost.

The implementation suggested here should ensure that the state is evaluated.
