### PR TITLE
MonadAccum, MonadSelect, + mtl instances for SelectT/AccumT

### DIFF
--- a/Control/Monad/Accum.hs
+++ b/Control/Monad/Accum.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE CPP #-}
+{- |
+Module      :  Control.Monad.Accum
+Copyright   :  ???
+License     :  BSD-style (see the file LICENSE)
+
+Maintainer  :  libraries@haskell.org
+Stability   :  experimental
+Portability :  non-portable (multi-parameter type classes)
+
+Provides append-only accumulation during the computation.  For more general
+access, use "Control.Monad.State" instead.
+-}
+
+{-
+  Rendered by Michael Weber <mailto:michael.weber@post.rwth-aachen.de>,
+  inspired by the Haskell Monad Template Library from
+    Andy Gill (<http://web.cecs.pdx.edu/~andy/>)
+-}
+module Control.Monad.Accum
+  (
+    -- * MonadAccum class
+    MonadAccum(..),
+    looks,
+    -- * The Accum monad
+    Accum,
+    runAccum,
+    evalAccum,
+    execAccum,
+    mapAccum,
+    -- * The AccumT monad transformer
+    AccumT(AccumT),
+    runAccumT,
+    evalAccumT,
+    execAccumT,
+    mapAccumT,
+    module Control.Monad,
+    module Control.Monad.Fix,
+    module Control.Monad.Trans,
+  ) where
+
+import Control.Monad.Accum.Class
+import Control.Monad.Trans
+import Control.Monad.Trans.Accum
+        (Accum, runAccum, evalAccum, execAccum, mapAccum,
+         AccumT(AccumT), runAccumT, evalAccumT, execAccumT, mapAccumT)
+
+import Control.Monad
+import Control.Monad.Fix
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 707
+import Control.Monad.Instances ()
+#endif
+

--- a/Control/Monad/Accum/Class.hs
+++ b/Control/Monad/Accum/Class.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- Search for UndecidableInstances to see why this is needed
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Accum.Class
+-- Copyright   :  ???
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  libraries@haskell.org
+-- Stability   :  experimental
+-- Portability :  non-portable (multi-param classes, functional dependencies)
+--
+-- MonadAccum class.
+--
+
+-----------------------------------------------------------------------------
+
+module Control.Monad.Accum.Class (
+    MonadAccum(..),
+    looks
+  ) where
+
+import Control.Monad.Trans.Cont
+import Control.Monad.Trans.Error
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Identity
+import Control.Monad.Trans.List
+import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Reader
+import qualified Control.Monad.Trans.Accum as A
+import qualified Control.Monad.Trans.RWS.Lazy as LazyRWS (RWST, get, put, state)
+import qualified Control.Monad.Trans.RWS.Strict as StrictRWS (RWST, get, put, state)
+import qualified Control.Monad.Trans.State.Lazy as Lazy (StateT, get, put, state)
+import qualified Control.Monad.Trans.State.Strict as Strict (StateT, get, put, state)
+import Control.Monad.Trans.Writer.Lazy as Lazy
+import Control.Monad.Trans.Writer.Strict as Strict
+
+import Control.Monad.Trans.Class (lift)
+import Control.Monad
+import Data.Monoid
+
+-- ---------------------------------------------------------------------------
+
+-- | Minimal definition is either both of @get@ and @put@ or just @state@
+class (Monoid w, Monad m) => MonadAccum w m | m -> w where
+    -- | @'add' w@ is an action that produces the output @w@.
+    add :: w -> m ()
+
+    -- | 'look' is an action that fetchs all the previously accumulated
+    -- output.
+    look :: m w
+
+#if __GLASGOW_HASKELL__ >= 707
+    {-# MINIMAL add, look #-}
+#endif
+
+-- | 'looks' is an action that retrieves a function of the previously
+-- accumulated output.
+looks :: MonadAccum w m => (w -> a) -> m a
+looks f = fmap f look
+
+instance (Monoid w, Monad m) => MonadAccum w (A.AccumT w m) where
+    add  = A.add
+    look = A.look
+
+-- ---------------------------------------------------------------------------
+-- Instances for other mtl transformers
+--
+-- All of these instances need UndecidableInstances,
+-- because they do not satisfy the coverage condition.
+
+instance MonadAccum w m => MonadAccum w (ContT r m) where
+    add  = lift . add
+    look = lift look
+
+instance (Error e, MonadAccum w m) => MonadAccum w (ErrorT e m) where
+    add  = lift . add
+    look = lift look
+
+instance MonadAccum w m => MonadAccum w (ExceptT e m) where
+    add  = lift . add
+    look = lift look
+
+instance MonadAccum w m => MonadAccum w (IdentityT m) where
+    add  = lift . add
+    look = lift look
+
+instance MonadAccum w m => MonadAccum w (ListT m) where
+    add  = lift . add
+    look = lift look
+
+instance MonadAccum w m => MonadAccum w (MaybeT m) where
+    add  = lift . add
+    look = lift look
+
+instance MonadAccum w m => MonadAccum w (ReaderT r m) where
+    add  = lift . add
+    look = lift look
+
+instance MonadAccum w m => MonadAccum w (Lazy.StateT s m) where
+    add  = lift . add
+    look = lift look
+
+instance MonadAccum w m => MonadAccum w (Strict.StateT s m) where
+    add  = lift . add
+    look = lift look
+
+instance (Monoid v, MonadAccum w m) => MonadAccum w (Lazy.WriterT v m) where
+    add  = lift . add
+    look = lift look
+
+instance (Monoid v, MonadAccum w m) => MonadAccum w (Strict.WriterT v m) where
+    add  = lift . add
+    look = lift look
+

--- a/Control/Monad/Cont/Class.hs
+++ b/Control/Monad/Cont/Class.hs
@@ -55,6 +55,7 @@ module Control.Monad.Cont.Class (
 
 import Control.Monad.Trans.Cont (ContT)
 import qualified Control.Monad.Trans.Cont as ContT
+import Control.Monad.Trans.Accum as Accum
 import Control.Monad.Trans.Error as Error
 import Control.Monad.Trans.Except as Except
 import Control.Monad.Trans.Identity as Identity
@@ -100,6 +101,10 @@ instance MonadCont (ContT r m) where
 
 -- ---------------------------------------------------------------------------
 -- Instances for other mtl transformers
+
+instance (Monoid w, MonadCont m) => MonadCont (AccumT w m) where
+    callCC f = AccumT $ \s -> callCC $ \c ->
+        runAccumT (f (\a -> AccumT $ \s' -> c (a, s'))) s
 
 instance (Error e, MonadCont m) => MonadCont (ErrorT e m) where
     callCC = Error.liftCallCC callCC

--- a/Control/Monad/Error/Class.hs
+++ b/Control/Monad/Error/Class.hs
@@ -44,6 +44,7 @@ module Control.Monad.Error.Class (
     liftEither,
   ) where
 
+import Control.Monad.Trans.Accum as Accum
 import Control.Monad.Trans.Except (Except, ExceptT)
 import Control.Monad.Trans.Error (Error(..), ErrorT)
 import qualified Control.Monad.Trans.Except as ExceptT (throwE, catchE)
@@ -68,7 +69,7 @@ import Control.Monad.Instances ()
 #endif
 
 import Data.Monoid
-import Prelude (Either(..), Maybe(..), either, (.), IO)
+import Prelude (Either(..), Maybe(..), either, (.), IO, ($))
 
 {- |
 The strategy of combining computations that can throw exceptions
@@ -146,6 +147,11 @@ instance Monad m => MonadError e (ExceptT e m) where
 --
 -- All of these instances need UndecidableInstances,
 -- because they do not satisfy the coverage condition.
+
+instance (Monoid w, MonadError e m) => MonadError e (AccumT w m) where
+    throwError = lift . throwError
+    catchError m h = AccumT $ \s -> runAccumT m s `catchError` \e ->
+        runAccumT (h e) s
 
 instance MonadError e m => MonadError e (IdentityT m) where
     throwError = lift . throwError

--- a/Control/Monad/RWS/Class.hs
+++ b/Control/Monad/RWS/Class.hs
@@ -34,6 +34,7 @@ import Control.Monad.Reader.Class
 import Control.Monad.State.Class
 import Control.Monad.Writer.Class
 
+import Control.Monad.Trans.Accum
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Error(Error, ErrorT)
 import Control.Monad.Trans.Except(ExceptT)
@@ -57,6 +58,7 @@ instance (Monoid w, Monad m) => MonadRWS r w s (Strict.RWST r w s m)
 -- All of these instances need UndecidableInstances,
 -- because they do not satisfy the coverage condition.
 
+instance (Monoid v, MonadRWS r w s m) => MonadRWS r w s (AccumT v m)
 instance MonadRWS r w s m => MonadRWS r w s (ExceptT e m)
 instance (Error e, MonadRWS r w s m) => MonadRWS r w s (ErrorT e m)
 instance MonadRWS r w s m => MonadRWS r w s (IdentityT m)

--- a/Control/Monad/Reader/Class.hs
+++ b/Control/Monad/Reader/Class.hs
@@ -46,6 +46,7 @@ module Control.Monad.Reader.Class (
     asks,
     ) where
 
+import Control.Monad.Trans.Accum
 import Control.Monad.Trans.Cont as Cont
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Error
@@ -126,6 +127,11 @@ instance (Monad m, Monoid w) => MonadReader r (StrictRWS.RWST r w s m) where
 --
 -- All of these instances need UndecidableInstances,
 -- because they do not satisfy the coverage condition.
+
+instance (Monoid w, MonadReader r m) => MonadReader r (AccumT w m) where
+    ask   = lift ask
+    local = mapAccumT . local
+    reader = lift . reader
 
 instance MonadReader r' m => MonadReader r' (ContT r m) where
     ask   = lift ask

--- a/Control/Monad/State/Class.hs
+++ b/Control/Monad/State/Class.hs
@@ -32,6 +32,7 @@ module Control.Monad.State.Class (
     gets
   ) where
 
+import Control.Monad.Trans.Accum
 import Control.Monad.Trans.Cont
 import Control.Monad.Trans.Error
 import Control.Monad.Trans.Except
@@ -126,6 +127,11 @@ instance (Monad m, Monoid w) => MonadState s (StrictRWS.RWST r w s m) where
 --
 -- All of these instances need UndecidableInstances,
 -- because they do not satisfy the coverage condition.
+
+instance (Monoid w, MonadState s m) => MonadState s (AccumT w m) where
+    get = lift get
+    put = lift . put
+    state = lift . state
 
 instance MonadState s m => MonadState s (ContT r m) where
     get = lift get

--- a/Control/Monad/Writer/Class.hs
+++ b/Control/Monad/Writer/Class.hs
@@ -30,6 +30,7 @@ module Control.Monad.Writer.Class (
     censor,
   ) where
 
+import Control.Monad.Trans.Accum as Accum
 import Control.Monad.Trans.Error as Error
 import Control.Monad.Trans.Except as Except
 import Control.Monad.Trans.Identity as Identity
@@ -140,6 +141,12 @@ instance (Monoid w, Monad m) => MonadWriter w (StrictRWS.RWST r w s m) where
 --
 -- All of these instances need UndecidableInstances,
 -- because they do not satisfy the coverage condition.
+
+instance (Monoid v, MonadWriter w m) => MonadWriter w (AccumT v m) where
+    writer = lift . writer
+    tell   = lift . tell
+    listen m = AccumT $ fmap (\(~((x,v),w)) -> ((x,w),v)) . listen . runAccumT m
+    pass   m = AccumT $ pass . fmap (\(~((x,v),w)) -> ((x,w),v)) . runAccumT m
 
 instance (Error e, MonadWriter w m) => MonadWriter w (ErrorT e m) where
     writer = lift . writer

--- a/mtl.cabal
+++ b/mtl.cabal
@@ -34,6 +34,8 @@ source-repository head
 
 Library
   exposed-modules:
+    Control.Monad.Accum
+    Control.Monad.Accum.Class
     Control.Monad.Cont
     Control.Monad.Cont.Class
     Control.Monad.Error
@@ -56,7 +58,7 @@ Library
     Control.Monad.Writer.Class
     Control.Monad.Writer.Lazy
     Control.Monad.Writer.Strict
-  build-depends: base < 5, transformers >= 0.4 && <0.6
+  build-depends: base < 5, transformers >= 0.5.5 && <0.6
 
   default-language: Haskell2010
   other-extensions:


### PR DESCRIPTION
Can't seem to find a branches with progress on #44, so here's my shot.

Tried my best to follow the structure of the other modules.  WIP, as I've only added MonadAccum and mtl instances for AccumT.

Some notes --

* For instances of MonadCont and MonadError and MonadWriter, etc., with somewhat "involved" functions (callCC, catch, listen, pass), the convention seems to be to implement these lifted functions in *transformers* (`liftListen`, etc.) instead of mtl.  It would probably make more sense to do the same for `AccumT` (define `Control.Monad.Trans.Accum.liftListen` in *transformers*, etc.) than in here, so we might want to get that merged into *transformers* before committing to the currently inlined defined versions I have here.

* `MonadAccum` only has `add` and `look`.  Having it include `accum`, I feel, (like `MonadState` has `state`) would be pretty strongly against the spirit of the interface.

* Not exactly sure what to put for copyrights on these new modules?