### PR TITLE
Export evalCont/evalContT

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+Unreleased
+----------
+* `Control.Monad.Cont` now re-exports `evalCont` and `evalContT`
+
 2.2.2
 -----
 * `Control.Monad.Identity` now re-exports `Control.Monad.Trans.Identity`

--- a/Control/Monad/Cont.hs
+++ b/Control/Monad/Cont.hs
@@ -55,11 +55,13 @@ module Control.Monad.Cont (
     Cont,
     cont,
     runCont,
+    evalCont,
     mapCont,
     withCont,
     -- * The ContT monad transformer
     ContT(ContT),
     runContT,
+    evalContT,
     mapContT,
     withContT,
     module Control.Monad,


### PR DESCRIPTION
Fixes #64, and includes a version bump and changelog entry in a separate commit, in case you want to cherry-pick one or the other.