### PR TITLE
Support Control.Monad.Trans.{Writer,RWS}.CPS from transformers 0.5.6

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Add instances for `Control.Monad.Trans.Writer.CPS` and `Control.Monad.Trans.RWS.CPS` from `transformers` 0.5.6 and add `Control.Monad.Writer.CPS` and `Control.Monad.RWS.CPS`.
 * `Control.Monad.Cont` now re-exports `evalCont` and `evalContT`
 * Add `tryError`, `withError`, `handleError`, and `mapError` to
   `Control.Monad.Error.Class`, and re-export from `Control.Monad.Except`.

--- a/Control/Monad/Cont/Class.hs
+++ b/Control/Monad/Cont/Class.hs
@@ -68,6 +68,11 @@ import Control.Monad.Trans.State.Strict as StrictState
 import Control.Monad.Trans.Writer.Lazy as LazyWriter
 import Control.Monad.Trans.Writer.Strict as StrictWriter
 
+#if MIN_VERSION_transformers(0,5,6)
+import Control.Monad.Trans.RWS.CPS as CPSRWS
+import Control.Monad.Trans.Writer.CPS as CPSWriter
+#endif
+
 import Control.Monad
 import Data.Monoid
 
@@ -137,3 +142,13 @@ instance (Monoid w, MonadCont m) => MonadCont (LazyWriter.WriterT w m) where
 
 instance (Monoid w, MonadCont m) => MonadCont (StrictWriter.WriterT w m) where
     callCC = StrictWriter.liftCallCC callCC
+
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monoid w, MonadCont m) => MonadCont (CPSRWS.RWST r w s m) where
+    callCC = CPSRWS.liftCallCC' callCC
+
+-- | @since 2.3
+instance (Monoid w, MonadCont m) => MonadCont (CPSWriter.WriterT w m) where
+    callCC = CPSWriter.liftCallCC callCC
+#endif

--- a/Control/Monad/Error/Class.hs
+++ b/Control/Monad/Error/Class.hs
@@ -64,6 +64,11 @@ import Control.Monad.Trans.State.Strict as StrictState
 import Control.Monad.Trans.Writer.Lazy as LazyWriter
 import Control.Monad.Trans.Writer.Strict as StrictWriter
 
+#if MIN_VERSION_transformers(0,5,6)
+import Control.Monad.Trans.RWS.CPS as CPSRWS
+import Control.Monad.Trans.Writer.CPS as CPSWriter
+#endif
+
 import Control.Monad.Trans.Class (lift)
 import Control.Exception (IOException, catch, ioError)
 import Control.Monad
@@ -195,6 +200,18 @@ instance (Monoid w, MonadError e m) => MonadError e (LazyWriter.WriterT w m) whe
 instance (Monoid w, MonadError e m) => MonadError e (StrictWriter.WriterT w m) where
     throwError = lift . throwError
     catchError = StrictWriter.liftCatch catchError
+
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monoid w, MonadError e m) => MonadError e (CPSRWS.RWST r w s m) where
+    throwError = lift . throwError
+    catchError = CPSRWS.liftCatch catchError
+
+-- | @since 2.3
+instance (Monoid w, MonadError e m) => MonadError e (CPSWriter.WriterT w m) where
+    throwError = lift . throwError
+    catchError = CPSWriter.liftCatch catchError
+#endif
 
 -- | 'MonadError' analogue to the 'Control.Exception.try' function.
 tryError :: MonadError e m => m a -> m (Either e a)

--- a/Control/Monad/RWS/CPS.hs
+++ b/Control/Monad/RWS/CPS.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE CPP #-}
+#if MIN_VERSION_transformers(0,5,6)
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.RWS.Strict
+-- Copyright   :  (c) Andy Gill 2001,
+--                (c) Oregon Graduate Institute of Science and Technology, 2001
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  libraries@haskell.org
+-- Stability   :  experimental
+-- Portability :  non-portable (multi-param classes, functional dependencies)
+--
+-- Strict RWS monad that uses continuation-passing-style to achieve constant
+-- space usage.
+--
+--      Inspired by the paper
+--      /Functional Programming with Overloading and Higher-Order Polymorphism/,
+--        Mark P Jones (<http://web.cecs.pdx.edu/~mpj/>)
+--          Advanced School of Functional Programming, 1995.
+--
+-- /Since: mtl-2.3, transformers-0.5.6/
+-----------------------------------------------------------------------------
+
+module Control.Monad.RWS.CPS (
+    -- * The RWS monad
+    RWS,
+    rws,
+    runRWS,
+    evalRWS,
+    execRWS,
+    mapRWS,
+    withRWS,
+    -- * The RWST monad transformer
+    RWST,
+    runRWST,
+    evalRWST,
+    execRWST,
+    mapRWST,
+    withRWST,
+    -- * Strict Reader-writer-state monads
+    module Control.Monad.RWS.Class,
+    module Control.Monad,
+    module Control.Monad.Fix,
+    module Control.Monad.Trans,
+    module Data.Monoid,
+  ) where
+
+import Control.Monad.RWS.Class
+
+import Control.Monad.Trans
+import Control.Monad.Trans.RWS.CPS (
+    RWS, rws, runRWS, evalRWS, execRWS, mapRWS, withRWS,
+    RWST, runRWST, evalRWST, execRWST, mapRWST, withRWST)
+
+import Control.Monad
+import Control.Monad.Fix
+import Data.Monoid
+
+#else
+-- | This module ordinarily re-exports @Control.Monad.Trans.RWS.CPS@ from
+-- @transformers >= 0.5.6@, which is not currently installed. Therefore, this
+-- module currently provides nothing; use "Control.Monad.RWS.Lazy" or
+-- "Control.Monad.RWS.Strict" instead.
+module Control.Monad.RWS.CPS () where
+#endif

--- a/Control/Monad/RWS/Class.hs
+++ b/Control/Monad/RWS/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -39,7 +40,10 @@ import Control.Monad.Trans.Error(Error, ErrorT)
 import Control.Monad.Trans.Except(ExceptT)
 import Control.Monad.Trans.Maybe(MaybeT)
 import Control.Monad.Trans.Identity(IdentityT)
-import Control.Monad.Trans.RWS.Lazy as Lazy (RWST)
+#if MIN_VERSION_transformers(0,5,6)
+import qualified Control.Monad.Trans.RWS.CPS as CPS (RWST)
+#endif
+import qualified Control.Monad.Trans.RWS.Lazy as Lazy (RWST)
 import qualified Control.Monad.Trans.RWS.Strict as Strict (RWST)
 
 import Data.Monoid
@@ -47,10 +51,15 @@ import Data.Monoid
 class (Monoid w, MonadReader r m, MonadWriter w m, MonadState s m)
    => MonadRWS r w s m | m -> r, m -> w, m -> s
 
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monoid w, Monad m) => MonadRWS r w s (CPS.RWST r w s m)
+#endif
+
 instance (Monoid w, Monad m) => MonadRWS r w s (Lazy.RWST r w s m)
 
 instance (Monoid w, Monad m) => MonadRWS r w s (Strict.RWST r w s m)
- 
+
 ---------------------------------------------------------------------------
 -- Instances for other mtl transformers
 --

--- a/Control/Monad/Reader/Class.hs
+++ b/Control/Monad/Reader/Class.hs
@@ -61,6 +61,11 @@ import Control.Monad.Trans.State.Strict as Strict
 import Control.Monad.Trans.Writer.Lazy as Lazy
 import Control.Monad.Trans.Writer.Strict as Strict
 
+#if MIN_VERSION_transformers(0,5,6)
+import qualified Control.Monad.Trans.RWS.CPS as CPSRWS (RWST, ask, local, reader)
+import Control.Monad.Trans.Writer.CPS as CPS
+#endif
+
 import Control.Monad.Trans.Class (lift)
 import Control.Monad
 import Data.Monoid
@@ -110,6 +115,14 @@ instance Monad m => MonadReader r (ReaderT r m) where
     ask = ReaderT.ask
     local = ReaderT.local
     reader = ReaderT.reader
+
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monad m, Monoid w) => MonadReader r (CPSRWS.RWST r w s m) where
+    ask = CPSRWS.ask
+    local = CPSRWS.local
+    reader = CPSRWS.reader
+#endif
 
 instance (Monad m, Monoid w) => MonadReader r (LazyRWS.RWST r w s m) where
     ask = LazyRWS.ask
@@ -167,6 +180,14 @@ instance MonadReader r m => MonadReader r (Strict.StateT s m) where
     ask   = lift ask
     local = Strict.mapStateT . local
     reader = lift . reader
+
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monoid w, MonadReader r m) => MonadReader r (CPS.WriterT w m) where
+    ask   = lift ask
+    local = CPS.mapWriterT . local
+    reader = lift . reader
+#endif
 
 instance (Monoid w, MonadReader r m) => MonadReader r (Lazy.WriterT w m) where
     ask   = lift ask

--- a/Control/Monad/State/Class.hs
+++ b/Control/Monad/State/Class.hs
@@ -46,6 +46,11 @@ import qualified Control.Monad.Trans.State.Strict as Strict (StateT, get, put, s
 import Control.Monad.Trans.Writer.Lazy as Lazy
 import Control.Monad.Trans.Writer.Strict as Strict
 
+#if MIN_VERSION_transformers(0,5,6)
+import qualified Control.Monad.Trans.RWS.CPS as CPSRWS (RWST, get, put, state)
+import Control.Monad.Trans.Writer.CPS as CPS
+#endif
+
 import Control.Monad.Trans.Class (lift)
 import Control.Monad
 import Data.Monoid
@@ -113,6 +118,14 @@ instance Monad m => MonadState s (Strict.StateT s m) where
     put = Strict.put
     state = Strict.state
 
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monad m, Monoid w) => MonadState s (CPSRWS.RWST r w s m) where
+    get = CPSRWS.get
+    put = CPSRWS.put
+    state = CPSRWS.state
+#endif
+
 instance (Monad m, Monoid w) => MonadState s (LazyRWS.RWST r w s m) where
     get = LazyRWS.get
     put = LazyRWS.put
@@ -164,6 +177,14 @@ instance MonadState s m => MonadState s (ReaderT r m) where
     get = lift get
     put = lift . put
     state = lift . state
+
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monoid w, MonadState s m) => MonadState s (CPS.WriterT w m) where
+    get = lift get
+    put = lift . put
+    state = lift . state
+#endif
 
 instance (Monoid w, MonadState s m) => MonadState s (Lazy.WriterT w m) where
     get = lift get

--- a/Control/Monad/Writer/CPS.hs
+++ b/Control/Monad/Writer/CPS.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE CPP #-}
+#if MIN_VERSION_transformers(0,5,6)
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Writer.Strict
+-- Copyright   :  (c) Andy Gill 2001,
+--                (c) Oregon Graduate Institute of Science and Technology, 2001
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  libraries@haskell.org
+-- Stability   :  experimental
+-- Portability :  non-portable (multi-param classes, functional dependencies)
+--
+-- Strict writer monads that use continuation-passing-style to achieve constant
+-- space usage.
+--
+--      Inspired by the paper
+--      /Functional Programming with Overloading and Higher-Order Polymorphism/,
+--        Mark P Jones (<http://web.cecs.pdx.edu/~mpj/pubs/springschool.html>)
+--          Advanced School of Functional Programming, 1995.
+--
+-- /Since: mtl-2.3, transformers-0.5.6/
+-----------------------------------------------------------------------------
+
+module Control.Monad.Writer.CPS (
+    -- * MonadWriter class
+    MonadWriter(..),
+    listens,
+    censor,
+    -- * The Writer monad
+    Writer,
+    runWriter,
+    execWriter,
+    mapWriter,
+    -- * The WriterT monad transformer
+    WriterT,
+    execWriterT,
+    mapWriterT,
+    module Control.Monad,
+    module Control.Monad.Fix,
+    module Control.Monad.Trans,
+    module Data.Monoid,
+  ) where
+
+import Control.Monad.Writer.Class
+
+import Control.Monad.Trans
+import Control.Monad.Trans.Writer.CPS (
+        Writer, runWriter, execWriter, mapWriter,
+        WriterT, execWriterT, mapWriterT)
+
+import Control.Monad
+import Control.Monad.Fix
+import Data.Monoid
+
+#else
+-- | This module ordinarily re-exports @Control.Monad.Trans.Writer.CPS@ from
+-- @transformers >= 0.5.6@, which is not currently installed. Therefore, this
+-- module currently provides nothing; use "Control.Monad.Writer.Lazy" or
+-- "Control.Monad.Writer.Strict" instead.
+module Control.Monad.Writer.CPS () where
+#endif

--- a/Control/Monad/Writer/Class.hs
+++ b/Control/Monad/Writer/Class.hs
@@ -46,6 +46,13 @@ import qualified Control.Monad.Trans.Writer.Lazy as Lazy (
 import qualified Control.Monad.Trans.Writer.Strict as Strict (
         WriterT, writer, tell, listen, pass)
 
+#if MIN_VERSION_transformers(0,5,6)
+import qualified Control.Monad.Trans.RWS.CPS as CPSRWS (
+        RWST, writer, tell, listen, pass)
+import qualified Control.Monad.Trans.Writer.CPS as CPS (
+        WriterT, writer, tell, listen, pass)
+#endif
+
 import Control.Monad.Trans.Class (lift)
 import Control.Monad
 import Data.Monoid
@@ -114,6 +121,15 @@ instance (Monoid w) => MonadWriter w ((,) w) where
   pass ~(w, (a, f)) = (f w, a)
 #endif
 
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monoid w, Monad m) => MonadWriter w (CPS.WriterT w m) where
+    writer = CPS.writer
+    tell   = CPS.tell
+    listen = CPS.listen
+    pass   = CPS.pass
+#endif
+
 instance (Monoid w, Monad m) => MonadWriter w (Lazy.WriterT w m) where
     writer = Lazy.writer
     tell   = Lazy.tell
@@ -125,6 +141,15 @@ instance (Monoid w, Monad m) => MonadWriter w (Strict.WriterT w m) where
     tell   = Strict.tell
     listen = Strict.listen
     pass   = Strict.pass
+
+#if MIN_VERSION_transformers(0,5,6)
+-- | @since 2.3
+instance (Monoid w, Monad m) => MonadWriter w (CPSRWS.RWST r w s m) where
+    writer = CPSRWS.writer
+    tell   = CPSRWS.tell
+    listen = CPSRWS.listen
+    pass   = CPSRWS.pass
+#endif
 
 instance (Monoid w, Monad m) => MonadWriter w (LazyRWS.RWST r w s m) where
     writer = LazyRWS.writer

--- a/mtl.cabal
+++ b/mtl.cabal
@@ -42,6 +42,7 @@ Library
     Control.Monad.List
     Control.Monad.RWS
     Control.Monad.RWS.Class
+    Control.Monad.RWS.CPS
     Control.Monad.RWS.Lazy
     Control.Monad.RWS.Strict
     Control.Monad.Reader
@@ -53,6 +54,7 @@ Library
     Control.Monad.Trans
     Control.Monad.Writer
     Control.Monad.Writer.Class
+    Control.Monad.Writer.CPS
     Control.Monad.Writer.Lazy
     Control.Monad.Writer.Strict
   build-depends: base < 5, transformers >= 0.4 && <0.6


### PR DESCRIPTION
`transformers-0.5.6.0` adds new `Control.Monad.Trans.Writer.CPS` and `Control.Monad.Trans.RWS.CPS` monad transformers, so this PR adds support for them in `mtl`.

I’ve taken the liberty of bumping the version to 2.3, since this seems like a significant enough change to do so, and picking what the next release’s version number will be was necessary for the `@since` annotations in the docs. Let me know if you’d like me to do something else, and I’ll change it.