### PR TITLE
PVP adherence: Stop re-exporting from other packages (`base`)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,9 @@ Unreleased
 * `Control.Monad.Cont` now re-exports `evalCont` and `evalContT`
 * Add `tryError`, `withError`, `handleError`, and `mapError` to
   `Control.Monad.Error.Class`, and re-export from `Control.Monad.Except`.
+* Stop re-exporting Control.Monad and Control.Monad.Fix from each non-.Class module
+* Stop re-exporting Control.Monad.IO.Class from Control.Monad.Trans
+* Stop re-exporting Data.Monoid from Control.Monad.Writer. modules
 
 2.2.2
 -----

--- a/Control/Monad/Cont.hs
+++ b/Control/Monad/Cont.hs
@@ -64,14 +64,13 @@ module Control.Monad.Cont (
     evalContT,
     mapContT,
     withContT,
-    module Control.Monad,
     module Control.Monad.Trans,
     -- * Example 1: Simple Continuation Usage
     -- $simpleContExample
 
     -- * Example 2: Using @callCC@
     -- $callCCExample
-    
+
     -- * Example 3: Using @ContT@ Monad Transformer
     -- $ContTExample
   ) where

--- a/Control/Monad/Error.hs
+++ b/Control/Monad/Error.hs
@@ -41,8 +41,6 @@ module Control.Monad.Error
     ErrorT(ErrorT),
     runErrorT,
     mapErrorT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Example 1: Custom Error Data Type
     -- $customErrorExample

--- a/Control/Monad/Except.hs
+++ b/Control/Monad/Except.hs
@@ -54,8 +54,6 @@ module Control.Monad.Except
     mapExcept,
     withExcept,
 
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Example 1: Custom Error Data Type
     -- $customErrorExample

--- a/Control/Monad/Identity.hs
+++ b/Control/Monad/Identity.hs
@@ -35,9 +35,6 @@ version of that monad.
 module Control.Monad.Identity (
     module Data.Functor.Identity,
     module Control.Monad.Trans.Identity,
-
-    module Control.Monad,
-    module Control.Monad.Fix,
    ) where
 
 import Data.Functor.Identity

--- a/Control/Monad/List.hs
+++ b/Control/Monad/List.hs
@@ -16,8 +16,6 @@
 module Control.Monad.List (
     ListT(..),
     mapListT,
-    module Control.Monad,
-    module Control.Monad.Trans,
   ) where
 
 import Control.Monad

--- a/Control/Monad/RWS/CPS.hs
+++ b/Control/Monad/RWS/CPS.hs
@@ -40,8 +40,6 @@ module Control.Monad.RWS.CPS (
     withRWST,
     -- * Strict Reader-writer-state monads
     module Control.Monad.RWS.Class,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     module Data.Monoid,
   ) where

--- a/Control/Monad/RWS/Lazy.hs
+++ b/Control/Monad/RWS/Lazy.hs
@@ -35,8 +35,6 @@ module Control.Monad.RWS.Lazy (
     withRWST,
     -- * Lazy Reader-writer-state monads
     module Control.Monad.RWS.Class,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     module Data.Monoid,
   ) where

--- a/Control/Monad/RWS/Strict.hs
+++ b/Control/Monad/RWS/Strict.hs
@@ -35,8 +35,6 @@ module Control.Monad.RWS.Strict (
     withRWST,
     -- * Strict Reader-writer-state monads
     module Control.Monad.RWS.Class,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     module Data.Monoid,
   ) where

--- a/Control/Monad/Reader.hs
+++ b/Control/Monad/Reader.hs
@@ -49,8 +49,6 @@ module Control.Monad.Reader (
     runReaderT,
     mapReaderT,
     withReaderT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Example 1: Simple Reader Usage
     -- $simpleReaderExample

--- a/Control/Monad/State/Lazy.hs
+++ b/Control/Monad/State/Lazy.hs
@@ -38,8 +38,6 @@ module Control.Monad.State.Lazy (
     execStateT,
     mapStateT,
     withStateT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Examples
     -- $examples

--- a/Control/Monad/State/Strict.hs
+++ b/Control/Monad/State/Strict.hs
@@ -38,8 +38,6 @@ module Control.Monad.State.Strict (
     execStateT,
     mapStateT,
     withStateT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Examples
     -- $examples

--- a/Control/Monad/Trans.hs
+++ b/Control/Monad/Trans.hs
@@ -27,7 +27,6 @@
 
 module Control.Monad.Trans (
     module Control.Monad.Trans.Class,
-    module Control.Monad.IO.Class
   ) where
 
 import Control.Monad.IO.Class

--- a/Control/Monad/Writer/CPS.hs
+++ b/Control/Monad/Writer/CPS.hs
@@ -36,8 +36,6 @@ module Control.Monad.Writer.CPS (
     WriterT,
     execWriterT,
     mapWriterT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     module Data.Monoid,
   ) where

--- a/Control/Monad/Writer/Lazy.hs
+++ b/Control/Monad/Writer/Lazy.hs
@@ -32,10 +32,7 @@ module Control.Monad.Writer.Lazy (
     runWriterT,
     execWriterT,
     mapWriterT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
-    module Data.Monoid,
   ) where
 
 import Control.Monad.Writer.Class

--- a/Control/Monad/Writer/Strict.hs
+++ b/Control/Monad/Writer/Strict.hs
@@ -31,10 +31,7 @@ module Control.Monad.Writer.Strict (
     WriterT(..),
     execWriterT,
     mapWriterT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
-    module Data.Monoid,
   ) where
 
 import Control.Monad.Writer.Class


### PR DESCRIPTION
- Stop re-exporting Control.Monad and Control.Monad.Fix from each
  non-*.Class module
- Stop re-exporting Control.Monad.IO.Class from Control.Monad.Trans
- Stop re-exporting Data.Monoid from Control.Monad.Writer.*

Resolves #68 

cc @phadej @ekmett 