### PR TITLE
Add modifyError  :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+2.3.1 -- Unreleased
+-----
+* Add `modifyError` to `Control.Monad.Error.Class`, and re-export from
+  `Control.Monad.Except`.
+
 2.3 -- 2022-05-07
 ---
 * Add instances for `Control.Monad.Trans.Writer.CPS` and 

--- a/Control/Monad/Error/Class.hs
+++ b/Control/Monad/Error/Class.hs
@@ -49,10 +49,11 @@ module Control.Monad.Error.Class (
     withError,
     handleError,
     mapError,
+    modifyError,
   ) where
 
 import Control.Monad.Trans.Except (ExceptT)
-import qualified Control.Monad.Trans.Except as ExceptT (throwE, catchE)
+import qualified Control.Monad.Trans.Except as ExceptT (catchE, runExceptT, throwE)
 import Control.Monad.Trans.Identity (IdentityT)
 import qualified Control.Monad.Trans.Identity as Identity
 import Control.Monad.Trans.Maybe (MaybeT)
@@ -211,7 +212,7 @@ tryError action = (Right <$> action) `catchError` (pure . Left)
 -- | 'MonadError' analogue to the 'withExceptT' function.
 -- Modify the value (but not the type) of an error.  The type is
 -- fixed because of the functional dependency @m -> e@.  If you need
--- to change the type of @e@ use 'mapError'.
+-- to change the type of @e@ use 'mapError' or 'modifyError'.
 withError :: MonadError e m => (e -> e) -> m a -> m a
 withError f action = tryError action >>= either (throwError . f) pure
 
@@ -225,3 +226,44 @@ handleError = flip catchError
 -- the result is lifted into the second 'MonadError' instance.
 mapError :: (MonadError e m, MonadError e' n) => (m (Either e a) -> n (Either e' b)) -> m a -> n b
 mapError f action = f (tryError action) >>= liftEither
+
+{- |
+A different 'MonadError' analogue to the 'withExceptT' function.
+Modify the value (and possibly the type) of an error in an @ExceptT@-transformed
+monad, while stripping the @ExceptT@ layer.
+
+This is useful for adapting the 'MonadError' constraint of a computation.
+
+For example:
+
+> data DatabaseError = ...
+>
+> performDatabaseQuery :: (MonadError DatabaseError m, ...) => m PersistedValue
+>
+> data AppError
+>   = MkDatabaseError DatabaseError
+>   | ...
+>
+> app :: (MonadError AppError m, ...) => m ()
+
+Given these types, @performDatabaseQuery@ cannot be used directly inside
+@app@, because the error types don't match. Using 'modifyError', an equivalent
+function with a different error type can be constructed:
+
+> performDatabaseQuery' :: (MonadError AppError m, ...) => m PersistedValue
+> performDatabaseQuery' = modifyError MkDatabaseError performDatabaseQuery
+
+Since the error types do match, @performDatabaseQuery'@ _can_ be used in @app@,
+assuming all other constraints carry over.
+
+This works by instantiating the @m@ in the type of @performDatabaseQuery@ to
+@ExceptT DatabaseError m'@, which satisfies the @MonadError DatabaseError@
+constraint. Immediately, the @ExceptT DatabaseError@ layer is unwrapped,
+producing 'Either' a @DatabaseError@ or a @PersistedValue@. If it's the former,
+the error is wrapped in @MkDatabaseError@ and re-thrown in the inner monad,
+otherwise the result value is returned.
+
+@since 2.3.1
+-}
+modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a
+modifyError f m = ExceptT.runExceptT m >>= either (throwError . f) pure

--- a/Control/Monad/Except.hs
+++ b/Control/Monad/Except.hs
@@ -42,6 +42,7 @@ module Control.Monad.Except
     Error.withError,
     Error.handleError,
     Error.mapError,
+    Error.modifyError,
     -- * The ExceptT monad transformer
     Except.ExceptT(ExceptT),
     Except.Except,


### PR DESCRIPTION
I recently came to this as a handy way to adapt a function from one `MonadError` to another. I couldn't find anything with this signature on hoogle, so I thought I'd add it here. I'm not 100% sure about the name, so any suggestions are welcome. I hope the docs are clear enough.