### PR TITLE
Remove re-exports of Control.Monad, ...

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -7,6 +7,7 @@
 * Remove `Control.Monad.List` and `Control.Monad.Error`
 * Remove instances of deprecated `ListT` and `ErrorT`
 * Add instances for `Control.Monad.Trans.Accum` and `Control.Monad.Trans.Select`
+* Remove re-exports of `Control.Monad`, `Control.Monad.Fix` and `Data.Monoid` modules
 
 2.2.2
 -----

--- a/Control/Monad/Cont.hs
+++ b/Control/Monad/Cont.hs
@@ -64,7 +64,6 @@ module Control.Monad.Cont (
     evalContT,
     mapContT,
     withContT,
-    module Control.Monad,
     module Control.Monad.Trans,
     -- * Example 1: Simple Continuation Usage
     -- $simpleContExample
@@ -78,7 +77,7 @@ module Control.Monad.Cont (
 
 import Control.Monad.Cont.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans (lift))
 import Control.Monad.Trans.Cont
 
 import Control.Monad

--- a/Control/Monad/Except.hs
+++ b/Control/Monad/Except.hs
@@ -54,8 +54,6 @@ module Control.Monad.Except
     mapExcept,
     withExcept,
 
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Example 1: Custom Error Data Type
     -- $customErrorExample
@@ -65,16 +63,13 @@ module Control.Monad.Except
   ) where
 
 import Control.Monad.Error.Class
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans (lift))
 import Control.Monad.Trans.Except
   ( ExceptT(ExceptT), Except, except
   , runExcept, runExceptT
   , mapExcept, mapExceptT
   , withExcept, withExceptT
   )
-
-import Control.Monad
-import Control.Monad.Fix
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 707
 import Control.Monad.Instances ()

--- a/Control/Monad/Identity.hs
+++ b/Control/Monad/Identity.hs
@@ -35,13 +35,10 @@ version of that monad.
 module Control.Monad.Identity (
     module Data.Functor.Identity,
     module Control.Monad.Trans.Identity,
-
-    module Control.Monad,
-    module Control.Monad.Fix,
    ) where
 
-import Data.Functor.Identity
+-- We do this so, because transformers-0.4.0.0
+-- https://hackage.haskell.org/package/transformers-0.4.0.0/docs/Data-Functor-Identity.html
+-- doesn't have runIdentity as a field name.
+import Data.Functor.Identity (Identity(Identity), runIdentity)
 import Control.Monad.Trans.Identity
-
-import Control.Monad
-import Control.Monad.Fix

--- a/Control/Monad/Identity.hs
+++ b/Control/Monad/Identity.hs
@@ -37,7 +37,7 @@ module Control.Monad.Identity (
     module Control.Monad.Trans.Identity,
    ) where
 
--- We do this so, because transformers-0.4.0.0
+-- We do this because transformers-0.4.0.0
 -- https://hackage.haskell.org/package/transformers-0.4.0.0/docs/Data-Functor-Identity.html
 -- doesn't have runIdentity as a field name.
 import Data.Functor.Identity (Identity(Identity), runIdentity)

--- a/Control/Monad/RWS/CPS.hs
+++ b/Control/Monad/RWS/CPS.hs
@@ -40,22 +40,15 @@ module Control.Monad.RWS.CPS (
     withRWST,
     -- * Strict Reader-writer-state monads
     module Control.Monad.RWS.Class,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
-    module Data.Monoid,
   ) where
 
 import Control.Monad.RWS.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans(lift))
 import Control.Monad.Trans.RWS.CPS (
     RWS, rws, runRWS, evalRWS, execRWS, mapRWS, withRWS,
     RWST, runRWST, evalRWST, execRWST, mapRWST, withRWST)
-
-import Control.Monad
-import Control.Monad.Fix
-import Data.Monoid
 
 #else
 -- | This module ordinarily re-exports @Control.Monad.Trans.RWS.CPS@ from

--- a/Control/Monad/RWS/Lazy.hs
+++ b/Control/Monad/RWS/Lazy.hs
@@ -35,19 +35,12 @@ module Control.Monad.RWS.Lazy (
     withRWST,
     -- * Lazy Reader-writer-state monads
     module Control.Monad.RWS.Class,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
-    module Data.Monoid,
   ) where
 
 import Control.Monad.RWS.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans(lift))
 import Control.Monad.Trans.RWS.Lazy (
     RWS, rws, runRWS, evalRWS, execRWS, mapRWS, withRWS,
     RWST(RWST), runRWST, evalRWST, execRWST, mapRWST, withRWST)
-
-import Control.Monad
-import Control.Monad.Fix
-import Data.Monoid

--- a/Control/Monad/RWS/Strict.hs
+++ b/Control/Monad/RWS/Strict.hs
@@ -35,19 +35,12 @@ module Control.Monad.RWS.Strict (
     withRWST,
     -- * Strict Reader-writer-state monads
     module Control.Monad.RWS.Class,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
-    module Data.Monoid,
   ) where
 
 import Control.Monad.RWS.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans(lift))
 import Control.Monad.Trans.RWS.Strict (
     RWS, rws, runRWS, evalRWS, execRWS, mapRWS, withRWS,
     RWST(RWST), runRWST, evalRWST, execRWST, mapRWST, withRWST)
-
-import Control.Monad
-import Control.Monad.Fix
-import Data.Monoid

--- a/Control/Monad/Reader.hs
+++ b/Control/Monad/Reader.hs
@@ -49,8 +49,6 @@ module Control.Monad.Reader (
     runReaderT,
     mapReaderT,
     withReaderT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Example 1: Simple Reader Usage
     -- $simpleReaderExample
@@ -67,10 +65,7 @@ import Control.Monad.Reader.Class
 import Control.Monad.Trans.Reader (
     Reader, runReader, mapReader, withReader,
     ReaderT(ReaderT), runReaderT, mapReaderT, withReaderT)
-import Control.Monad.Trans
-
-import Control.Monad
-import Control.Monad.Fix
+import Control.Monad.Trans (MonadTrans(lift))
 
 {- $simpleReaderExample
 

--- a/Control/Monad/State/Lazy.hs
+++ b/Control/Monad/State/Lazy.hs
@@ -38,8 +38,6 @@ module Control.Monad.State.Lazy (
     execStateT,
     mapStateT,
     withStateT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Examples
     -- $examples
@@ -47,13 +45,10 @@ module Control.Monad.State.Lazy (
 
 import Control.Monad.State.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans(lift))
 import Control.Monad.Trans.State.Lazy
         (State, runState, evalState, execState, mapState, withState,
          StateT(StateT), runStateT, evalStateT, execStateT, mapStateT, withStateT)
-
-import Control.Monad
-import Control.Monad.Fix
 
 -- ---------------------------------------------------------------------------
 -- $examples

--- a/Control/Monad/State/Strict.hs
+++ b/Control/Monad/State/Strict.hs
@@ -38,8 +38,6 @@ module Control.Monad.State.Strict (
     execStateT,
     mapStateT,
     withStateT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
     -- * Examples
     -- $examples
@@ -47,13 +45,10 @@ module Control.Monad.State.Strict (
 
 import Control.Monad.State.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans(lift))
 import Control.Monad.Trans.State.Strict
         (State, runState, evalState, execState, mapState, withState,
          StateT(StateT), runStateT, evalStateT, execStateT, mapStateT, withStateT)
-
-import Control.Monad
-import Control.Monad.Fix
 
 -- ---------------------------------------------------------------------------
 -- $examples

--- a/Control/Monad/Trans.hs
+++ b/Control/Monad/Trans.hs
@@ -30,5 +30,5 @@ module Control.Monad.Trans (
     module Control.Monad.IO.Class
   ) where
 
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Class
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.Trans.Class (MonadTrans(lift))

--- a/Control/Monad/Writer/CPS.hs
+++ b/Control/Monad/Writer/CPS.hs
@@ -36,22 +36,15 @@ module Control.Monad.Writer.CPS (
     WriterT,
     execWriterT,
     mapWriterT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
-    module Data.Monoid,
   ) where
 
 import Control.Monad.Writer.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans (lift))
 import Control.Monad.Trans.Writer.CPS (
         Writer, runWriter, execWriter, mapWriter,
         WriterT, execWriterT, mapWriterT)
-
-import Control.Monad
-import Control.Monad.Fix
-import Data.Monoid
 
 #else
 -- | This module ordinarily re-exports @Control.Monad.Trans.Writer.CPS@ from

--- a/Control/Monad/Writer/Lazy.hs
+++ b/Control/Monad/Writer/Lazy.hs
@@ -32,19 +32,12 @@ module Control.Monad.Writer.Lazy (
     runWriterT,
     execWriterT,
     mapWriterT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
-    module Data.Monoid,
   ) where
 
 import Control.Monad.Writer.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans(lift))
 import Control.Monad.Trans.Writer.Lazy (
         Writer, runWriter, execWriter, mapWriter,
         WriterT(WriterT), runWriterT, execWriterT, mapWriterT)
-
-import Control.Monad
-import Control.Monad.Fix
-import Data.Monoid

--- a/Control/Monad/Writer/Strict.hs
+++ b/Control/Monad/Writer/Strict.hs
@@ -31,15 +31,12 @@ module Control.Monad.Writer.Strict (
     WriterT(..),
     execWriterT,
     mapWriterT,
-    module Control.Monad,
-    module Control.Monad.Fix,
     module Control.Monad.Trans,
-    module Data.Monoid,
   ) where
 
 import Control.Monad.Writer.Class
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans(lift))
 import Control.Monad.Trans.Writer.Strict (
         Writer, runWriter, execWriter, mapWriter,
         WriterT(..), execWriterT, mapWriterT)


### PR DESCRIPTION
... Control.Monad.Fix and Data.Monoid modules.

Import Identity and MonadIO explicitly
in Control.Monad.Identity and Control.Monad.Trans
to avoid potential future API fluctuations.

Resolves #68 