### PR TITLE
Add note to Haddock about possible removals of re-exports

### DIFF
--- a/Control/Monad/Cont.hs
+++ b/Control/Monad/Cont.hs
@@ -64,8 +64,6 @@ module Control.Monad.Cont (
     evalContT,
     mapContT,
     withContT,
-    module Control.Monad,
-    module Control.Monad.Trans,
     -- * Example 1: Simple Continuation Usage
     -- $simpleContExample
 
@@ -74,6 +72,14 @@ module Control.Monad.Cont (
     
     -- * Example 3: Using @ContT@ Monad Transformer
     -- $ContTExample
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
+    module Control.Monad,
+    module Control.Monad.Trans,
   ) where
 
 import Control.Monad.Cont.Class

--- a/Control/Monad/Except.hs
+++ b/Control/Monad/Except.hs
@@ -54,14 +54,20 @@ module Control.Monad.Except
     mapExcept,
     withExcept,
 
-    module Control.Monad,
-    module Control.Monad.Fix,
-    module Control.Monad.Trans,
     -- * Example 1: Custom Error Data Type
     -- $customErrorExample
 
     -- * Example 2: Using ExceptT Monad Transformer
     -- $ExceptTExample
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
+    module Control.Monad,
+    module Control.Monad.Fix,
+    module Control.Monad.Trans,
   ) where
 
 import Control.Monad.Error.Class

--- a/Control/Monad/Identity.hs
+++ b/Control/Monad/Identity.hs
@@ -33,9 +33,14 @@ version of that monad.
 -}
 
 module Control.Monad.Identity (
-    module Data.Functor.Identity,
     module Control.Monad.Trans.Identity,
 
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- @Identity@ and @runIdentity@).
+    module Data.Functor.Identity,
     module Control.Monad,
     module Control.Monad.Fix,
    ) where

--- a/Control/Monad/RWS/CPS.hs
+++ b/Control/Monad/RWS/CPS.hs
@@ -40,6 +40,12 @@ module Control.Monad.RWS.CPS (
     withRWST,
     -- * Strict Reader-writer-state monads
     module Control.Monad.RWS.Class,
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
     module Control.Monad,
     module Control.Monad.Fix,
     module Control.Monad.Trans,

--- a/Control/Monad/RWS/Lazy.hs
+++ b/Control/Monad/RWS/Lazy.hs
@@ -35,6 +35,12 @@ module Control.Monad.RWS.Lazy (
     withRWST,
     -- * Lazy Reader-writer-state monads
     module Control.Monad.RWS.Class,
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
     module Control.Monad,
     module Control.Monad.Fix,
     module Control.Monad.Trans,

--- a/Control/Monad/RWS/Strict.hs
+++ b/Control/Monad/RWS/Strict.hs
@@ -35,6 +35,12 @@ module Control.Monad.RWS.Strict (
     withRWST,
     -- * Strict Reader-writer-state monads
     module Control.Monad.RWS.Class,
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
     module Control.Monad,
     module Control.Monad.Fix,
     module Control.Monad.Trans,

--- a/Control/Monad/Reader.hs
+++ b/Control/Monad/Reader.hs
@@ -49,9 +49,6 @@ module Control.Monad.Reader (
     runReaderT,
     mapReaderT,
     withReaderT,
-    module Control.Monad,
-    module Control.Monad.Fix,
-    module Control.Monad.Trans,
     -- * Example 1: Simple Reader Usage
     -- $simpleReaderExample
 
@@ -60,6 +57,15 @@ module Control.Monad.Reader (
 
     -- * Example 3: @ReaderT@ Monad Transformer
     -- $ReaderTExample
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
+    module Control.Monad,
+    module Control.Monad.Fix,
+    module Control.Monad.Trans,
     ) where
 
 import Control.Monad.Reader.Class

--- a/Control/Monad/State/Lazy.hs
+++ b/Control/Monad/State/Lazy.hs
@@ -38,11 +38,18 @@ module Control.Monad.State.Lazy (
     execStateT,
     mapStateT,
     withStateT,
+
+    -- * Examples
+    -- $examples
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
     module Control.Monad,
     module Control.Monad.Fix,
     module Control.Monad.Trans,
-    -- * Examples
-    -- $examples
   ) where
 
 import Control.Monad.State.Class

--- a/Control/Monad/State/Strict.hs
+++ b/Control/Monad/State/Strict.hs
@@ -38,11 +38,17 @@ module Control.Monad.State.Strict (
     execStateT,
     mapStateT,
     withStateT,
+    -- * Examples
+    -- $examples
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
     module Control.Monad,
     module Control.Monad.Fix,
     module Control.Monad.Trans,
-    -- * Examples
-    -- $examples
   ) where
 
 import Control.Monad.State.Class

--- a/Control/Monad/Trans.hs
+++ b/Control/Monad/Trans.hs
@@ -26,6 +26,10 @@
 -----------------------------------------------------------------------------
 
 module Control.Monad.Trans (
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- @MonadIO@, @liftIO@, @MonadTrans@ and @lift@).
+    module Control.Monad.Trans,
     module Control.Monad.Trans.Class,
     module Control.Monad.IO.Class
   ) where

--- a/Control/Monad/Writer/CPS.hs
+++ b/Control/Monad/Writer/CPS.hs
@@ -36,6 +36,12 @@ module Control.Monad.Writer.CPS (
     WriterT,
     execWriterT,
     mapWriterT,
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
     module Control.Monad,
     module Control.Monad.Fix,
     module Control.Monad.Trans,

--- a/Control/Monad/Writer/Lazy.hs
+++ b/Control/Monad/Writer/Lazy.hs
@@ -32,6 +32,12 @@ module Control.Monad.Writer.Lazy (
     runWriterT,
     execWriterT,
     mapWriterT,
+
+    -- * Deprecated re-export
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
     module Control.Monad,
     module Control.Monad.Fix,
     module Control.Monad.Trans,

--- a/Control/Monad/Writer/Strict.hs
+++ b/Control/Monad/Writer/Strict.hs
@@ -31,6 +31,12 @@ module Control.Monad.Writer.Strict (
     WriterT(..),
     execWriterT,
     mapWriterT,
+
+    -- * Deprecated re-exports
+    --
+    -- | ⚠ WARNING: Do not use anything imported via these re-exports.
+    -- They may be removed in the future without notice (except
+    -- 'Control.Monad.Trans.lift' from @Control.Monad.Trans@).
     module Control.Monad,
     module Control.Monad.Fix,
     module Control.Monad.Trans,


### PR DESCRIPTION
If one long term possibility is that we remove certain re-exports from `mtl` modules it seems like the documentation should warn about this.  Of course, this is not as good as deprecating the re-exports, but that functionality doesn't exist, and in its absence it seems like this would be an important way to communicate future potential breakage to users.

![screenshot](https://user-images.githubusercontent.com/1951567/162028377-2d9086ea-f605-413a-9930-f3a5c65e975e.png)
