### PR TITLE
Add release dates to CHANGELOG

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -19,7 +19,7 @@
   `LiftingSelect` deriving helper.
 * Remove re-exports of `Control.Monad`, `Control.Monad.Fix` and `Data.Monoid` modules
 
-2.2.2
+2.2.2 -- 2018-02-24
 -----
 * `Control.Monad.Identity` now re-exports `Control.Monad.Trans.Identity`
 * Fix a bug in which `Control.Monad.State.Class.modify'` was not as strict in
@@ -29,24 +29,24 @@
   `Control.Monad.Except{.Class}`
 * Add a `MonadWriter w ((,) w)` instance (when built against `base-4.9` or later)
 
-2.2.1
+2.2.1 -- 2014-06-02
 -------
 * Provide MINIMAL pragmas for `MonadState`, `MonadWriter`, `MonadReader`
 * Added a cyclic definition of `ask` in terms of `reader` for consistency with `get`/`put` vs. `state` and `tell` vs. `writer`
 * Fix deprecation warnings caused by `transformers` 0.4 deprecating `ErrorT`.
 * Added `Control.Monad.Except` in the style of the other `mtl` re-export modules
 
-2.2.0.1
+2.2.0.1 -- 2014-05-05
 -------
 * Fixed a bug caused by the change in how `transformers` 0.4 exports its data types. We will now export `runFooT` for each transformer again!
 
-2.2
+2.2 -- 2014-05-05
 ---
 * `transformers` 0.4 support
 * Added instances for `ExceptT`
 * Added `modify'` to `Control.Monad.State.*`
 
-2.1.3.1
+2.1.3.1 -- 2014-03-24
 -------
 * Avoid importing `Control.Monad.Instances` on GHC 7.8 to build without deprecation warnings.
 


### PR DESCRIPTION
based on each version's upload time in [hackage](https://hackage.haskell.org/package/mtl), and 2.1.3 isn't present in hackage actually


Close #107