### PR TITLE
Separate type of writer and accumulator

### DIFF
--- a/Control/Monad/Writer/Class.hs
+++ b/Control/Monad/Writer/Class.hs
@@ -198,9 +198,9 @@ instance MonadWriter w m => MonadWriter w (Strict.StateT s m) where
 --
 -- @since 2.3
 instance
-  ( Monoid w
+  ( Monoid w'
   , MonadWriter w m
-  ) => MonadWriter w (AccumT w m) where
+  ) => MonadWriter w (AccumT w' m) where
     writer = lift . writer
     tell   = lift . tell
     listen = Accum.liftListen listen


### PR DESCRIPTION
Previously, the instance required that both the `MonadWriter` and `AccumT` had the same type `w` as their accumulated value, even though in theory, they could be different. This was prompted by #120.

I don't have (easy) access to GHC 9.4. @Bodigrim - do you still get the redundant constraint warning? @emilypi - we should merge this in any case, as the original instance is definitely not what we intended.