### PR TITLE
Add initial docspec setup.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,15 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: cabal build containers
 
-      - name: Install and run cabal-docspec
-        if: matrix.os == 'ubuntu-latest'
-        working-directory: ${{ env.HOME }}
-        run: |
-          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20211114/cabal-docspec-0.0.0.20211114.xz > cabal-docspec.xz
-          echo 'e224700d9e8c9ec7ec6bc3f542ba433cd9925a5d356676c62a9bd1f2c8be8f8a cabal-docspec.xz' | sha256sum -c -
-          xz -d < cabal-docspec.xz > cabal-docspec
-          rm -f cabal-docspec.xz
-          chmod a+x cabal-docspec
-          ./cabal-docspec --version
-          ./cabal-docspec --builddir "${{ github.workspace }}/dist-newstyle" --extra-package containers
+      - uses: actions/checkout@v2.3.5
+        name: Get cabal-extras
+        with:
+          repository: kozross/cabal-extras
+          path: ./cabal-extras
+
+      - name: Install cabal-docspec
+        working-directory: cabal-extras/cabal-docspec
+        run: cabal install --install-method=copy --installdir=${{ runner.temp }} --overwrite-policy=always
+
+      - name: Run doctests
+        run: ${{ runner.temp }}/cabal-docspec --builddir ${{ github.workspace }}/dist-newstyle --extra-package containers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: 'latest'
+      - name: install cabal-docspec
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20211114/cabal-docspec-0.0.0.20211114.xz > cabal-docspec.xz
+          echo 'e224700d9e8c9ec7ec6bc3f542ba433cd9925a5d356676c62a9bd1f2c8be8f8a cabal-docspec.xz' | sha256sum -c -
+          xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
+          rm -f cabal-docspec.xz
+          chmod a+x $HOME/.cabal/bin/cabal-docspec
+          cabal-docspec --version
       - name: Configure
         run: cabal new-configure
       - name: Freeze
@@ -35,3 +44,5 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
       - name: Build
         run: cabal build
+      - name: Docspec
+        run: cabal-docspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: 'latest'
+      - run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH
       - name: install cabal-docspec
         run: |
           mkdir -p $HOME/.cabal/bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,35 +15,41 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ghc: ['8.6', '8.8', '8.10', '9.0', '9.2']
     steps:
+
       - name: Checkout base repo
         uses: actions/checkout@v2.3.5
+
       - name: Set up Haskell
         id: setup-haskell
         uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: 'latest'
-      - run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-      - name: install cabal-docspec
-        run: |
-          mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20211114/cabal-docspec-0.0.0.20211114.xz > cabal-docspec.xz
-          echo 'e224700d9e8c9ec7ec6bc3f542ba433cd9925a5d356676c62a9bd1f2c8be8f8a cabal-docspec.xz' | sha256sum -c -
-          xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
-          rm -f cabal-docspec.xz
-          chmod a+x $HOME/.cabal/bin/cabal-docspec
-          cabal-docspec --version
+
       - name: Configure
         run: cabal new-configure
+
       - name: Freeze
         run: cabal freeze
+
       - name: Cache
         uses: actions/cache@v2.1.3
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+
       - name: Build
         run: cabal build
-      - name: Docspec
-        run: cabal-docspec --extra-package containers
+
+      - name: Install and run cabal-docspec
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: ${{ env.HOME }}
+        run: |
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20211114/cabal-docspec-0.0.0.20211114.xz > cabal-docspec.xz
+          echo 'e224700d9e8c9ec7ec6bc3f542ba433cd9925a5d356676c62a9bd1f2c8be8f8a cabal-docspec.xz' | sha256sum -c -
+          xz -d < cabal-docspec.xz > cabal-docspec
+          rm -f cabal-docspec.xz
+          chmod a+x cabal-docspec
+          ./cabal-docspec --version
+          ./cabal-docspec --builddir "${{ github.workspace }}/dist-newstyle" --extra-package containers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Build
         run: cabal build
 
+      - name: Build containers (for docspec)
+        if: matrix.os == 'ubuntu-latest'
+        run: cabal build containers
+
       - name: Install and run cabal-docspec
         if: matrix.os == 'ubuntu-latest'
         working-directory: ${{ env.HOME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Build
         run: cabal build
       - name: Docspec
-        run: cabal-docspec
+        run: cabal-docspec --extra-package containers

--- a/Control/Monad/Cont.hs
+++ b/Control/Monad/Cont.hs
@@ -111,12 +111,12 @@ import qualified Control.Monad.Trans.Cont as Cont
 
 -- $callCCExample
 --
--- This example gives a taste of how escape continuations work, shows a typical
--- pattern for their usage.
+-- This example gives a taste of how escape continuations work, shows a
+-- typical pattern for their usage.
 --
--- Returns a string depending on the length of the name parameter.
--- If the provided string is empty, returns an error.
--- Otherwise, returns a welcome message.
+-- Returns a string depending on the length of the name parameter. If the
+-- provided string is empty, returns an error. Otherwise, returns a welcome
+-- message.
 --
 -- >>> import Control.Monad (when)
 --
@@ -140,13 +140,14 @@ import qualified Control.Monad.Trans.Cont as Cont
 -- (1) Runs an anonymous 'Cont' block and extracts value from it with
 -- @(\`runCont\` id)@. Here @id@ is the continuation, passed to the @Cont@ block.
 --
--- (1) Binds @response@ to the result of the following 'Control.Monad.Cont.Class.callCC' block,
--- binds @exit@ to the continuation.
+-- (1) Binds @response@ to the result of the following
+-- 'Control.Monad.Cont.Class.callCC' block, binds @exit@ to the
+-- continuation.
 --
--- (1) Validates @name@.
--- This approach illustrates advantage of using 'Control.Monad.Cont.Class.callCC' over @return@.
--- We pass the continuation to @validateName@,
--- and interrupt execution of the @Cont@ block from /inside/ of @validateName@.
+-- (1) Validates @name@. This approach illustrates advantage of using
+-- 'Control.Monad.Cont.Class.callCC' over @return@. We pass the
+-- continuation to @validateName@, and interrupt execution of the @Cont@
+-- block from /inside/ of @validateName@.
 --
 -- (1) Returns the welcome message from the 'Control.Monad.Cont.Class.callCC' block.
 -- This line is not executed if @validateName@ fails.
@@ -181,15 +182,18 @@ import qualified Control.Monad.Trans.Cont as Cont
 --   runContT (callCC askString) reportResult
 -- :}
 --
--- Action @askString@ requests user to enter a string,
--- and passes it to the continuation.
--- @askString@ takes as a parameter a continuation taking a string parameter,
--- and returning @IO ()@.
--- Compare its signature to 'runContT' definition.
+-- Action @askString@ requests user to enter a string, and passes it to the
+-- continuation. @askString@ takes as a parameter a continuation taking a
+-- string parameter, and returning @IO ()@. Compare its signature to
+-- 'runContT' definition.
 
 -- $labelExample
 --
--- The early exit behavior of 'Control.Monad.Cont.Class.callCC' can be leveraged to produce other idioms:
+-- The early exit behavior of 'Control.Monad.Cont.Class.callCC' can be
+-- leveraged to produce other idioms:
+--
+-- >>> import Control.Monad (when)
+-- >>> import Control.Monad.IO.Class (liftIO)
 --
 -- >>> :{
 -- whatsYourNameLabel :: IO ()
@@ -202,4 +206,6 @@ import qualified Control.Monad.Trans.Cont as Cont
 --   liftIO $ putStrLn $ "Welcome, " ++ name ++ "!"
 -- :}
 --
--- Calling @beggining@ will interrupt execution of the block, skipping the welcome message, which will be printed only once at the very end of the loop.
+-- Calling @beggining@ will interrupt execution of the block, skipping the
+-- welcome message, which will be printed only once at the very end of the
+-- loop.

--- a/Control/Monad/Except.hs
+++ b/Control/Monad/Except.hs
@@ -62,91 +62,112 @@ module Control.Monad.Except
 import qualified Control.Monad.Error.Class as Error
 import qualified Control.Monad.Trans.Except as Except
 
-{- $warning
-Please do not confuse 'ExceptT' and 'throwError' with 'Control.Exception.Exception' /
-'Control.Exception.SomeException' and 'Control.Exception.catch', respectively. The latter
-are for exceptions built into GHC, by default, and are mostly used from within the IO monad.
-They do not interact with the \"exceptions\" in this package at all. This package allows you
-to define a new kind of exception control mechanism which does not necessarily need your code to
-be placed in the IO monad.
+-- $warning
+--
+-- Please do not confuse 'ExceptT' and 'throwError' with
+-- 'Control.Exception.Exception' / 'Control.Exception.SomeException' and
+-- 'Control.Exception.catch', respectively. The latter are for exceptions
+-- built into GHC, by default, and are mostly used from within the IO
+-- monad. They do not interact with the \"exceptions\" in this package at
+-- all. This package allows you to define a new kind of exception control
+-- mechanism which does not necessarily need your code to be placed in the
+-- IO monad.
+--
+-- In short, all \"catching\" mechanisms in this library will be unable to
+-- catch exceptions thrown by functions in the "Control.Exception" module,
+-- and vice-versa.
 
-In short, all \"catching\" mechanisms in this library will be unable to catch exceptions thrown
-by functions in the "Control.Exception" module, and vice-versa.
--}
+-- $customErrorExample
+--
+-- Here is an example that demonstrates the use of a custom error data type with
+-- the 'throwError' and 'catchError' exception mechanism from 'MonadError'.
+-- The example throws an exception if the user enters an empty string
+-- or a string longer than 5 characters. Otherwise it prints length of the string.
+--
+-- This is the type to represent length calculation error.
+-- >>> :{
+-- data LengthError = EmptyString  -- Entered string was empty.
+--           | StringTooLong Int   -- A string is longer than 5 characters.
+--                                 -- Records a length of the string.
+--           | OtherError String   -- Other error, stores the problem description.
+-- :}
+--
+-- Converts LengthError to a readable message.
+-- >>> :{
+-- instance Show LengthError where
+--   show EmptyString = "The string was empty!"
+--   show (StringTooLong len) =
+--       "The length of the string (" ++ (show len) ++ ") is bigger than 5!"
+--   show (OtherError msg) = msg
+-- :}
+--
+-- For our monad type constructor, we use Either LengthError which
+-- represents failure using Left LengthError or a successful result of type
+-- a using Right a.
+--
+-- >>> type LengthMonad = Either LengthError
+--
+-- Attempts to calculate length and throws an error if the provided string
+-- is empty or longer than 5 characters.
+-- (Throwing an error in this monad means returning a 'Left'.)
+--
+-- >>> :{
+-- calculateLength :: String -> LengthMonad Int
+-- calculateLength [] = throwError EmptyString
+-- calculateLength s | len > 5 = throwError (StringTooLong len)
+--                   | otherwise = return len
+--   where len = length s
+-- :}
+--
+-- Prints result of the string length calculation.
+--
+-- >>> :{
+-- reportResult :: LengthMonad Int -> IO ()
+-- reportResult (Right len) = putStrLn ("The length of the string is " ++ (show len))
+-- reportResult (Left e) = putStrLn ("Length calculation failed with error: " ++ (show e))
+-- :}
+--
+-- >>> reportResult (calculateLength "hello")
+-- The length of the string is 5
 
-{- $customErrorExample
-Here is an example that demonstrates the use of a custom error data type with
-the 'throwError' and 'catchError' exception mechanism from 'MonadError'.
-The example throws an exception if the user enters an empty string
-or a string longer than 5 characters. Otherwise it prints length of the string.
-
->-- This is the type to represent length calculation error.
->data LengthError = EmptyString  -- Entered string was empty.
->          | StringTooLong Int   -- A string is longer than 5 characters.
->                                -- Records a length of the string.
->          | OtherError String   -- Other error, stores the problem description.
->
->-- Converts LengthError to a readable message.
->instance Show LengthError where
->  show EmptyString = "The string was empty!"
->  show (StringTooLong len) =
->      "The length of the string (" ++ (show len) ++ ") is bigger than 5!"
->  show (OtherError msg) = msg
->
->-- For our monad type constructor, we use Either LengthError
->-- which represents failure using Left LengthError
->-- or a successful result of type a using Right a.
->type LengthMonad = Either LengthError
->
->main = do
->  putStrLn "Please enter a string:"
->  s <- getLine
->  reportResult (calculateLength s)
->
->-- Attempts to calculate length and throws an error if the provided string is
->-- empty or longer than 5 characters.
->-- (Throwing an error in this monad means returning a 'Left'.)
->calculateLength :: String -> LengthMonad Int
->calculateLength [] = throwError EmptyString
->calculateLength s | len > 5 = throwError (StringTooLong len)
->                  | otherwise = return len
->  where len = length s
->
->-- Prints result of the string length calculation.
->reportResult :: LengthMonad Int -> IO ()
->reportResult (Right len) = putStrLn ("The length of the string is " ++ (show len))
->reportResult (Left e) = putStrLn ("Length calculation failed with error: " ++ (show e))
--}
-
-{- $ExceptTExample
-@'ExceptT'@ monad transformer can be used to add error handling to another monad.
-Here is an example how to combine it with an @IO@ monad:
-
->import Control.Monad.Except
->
->-- An IO monad which can return String failure.
->-- It is convenient to define the monad type of the combined monad,
->-- especially if we combine more monad transformers.
->type LengthMonad = ExceptT String IO
->
->main = do
->  -- runExceptT removes the ExceptT wrapper
->  r <- runExceptT calculateLength
->  reportResult r
->
->-- Asks user for a non-empty string and returns its length.
->-- Throws an error if user enters an empty string.
->calculateLength :: LengthMonad Int
->calculateLength = do
->  -- all the IO operations have to be lifted to the IO monad in the monad stack
->  liftIO $ putStrLn "Please enter a non-empty string: "
->  s <- liftIO getLine
->  if null s
->    then throwError "The string was empty!"
->    else return $ length s
->
->-- Prints result of the string length calculation.
->reportResult :: Either String Int -> IO ()
->reportResult (Right len) = putStrLn ("The length of the string is " ++ (show len))
->reportResult (Left e) = putStrLn ("Length calculation failed with error: " ++ (show e))
--}
+-- $ExceptTExample
+--
+-- @'ExceptT'@ monad transformer can be used to add error handling to
+-- another monad. Here is an example how to combine it with an @IO@ monad:
+--
+-- An IO monad which can return String failure. It is convenient to define
+-- the monad type of the combined monad, especially if we combine more
+-- monad transformers.
+--
+-- >>> import Control.Monad.Except
+-- >>> import Control.Monad.IO.Class (liftIO)
+-- >>> type LengthMonad = ExceptT String IO
+--
+-- Asks user for a non-empty string and returns its length.
+-- Throws an error if user enters an empty string.
+--
+-- >>> :{
+-- calculateLength :: LengthMonad Int
+-- calculateLength = do
+--   -- all the IO operations have to be lifted to the IO monad in the monad stack
+--   liftIO $ putStrLn "Please enter a non-empty string: "
+--   s <- liftIO getLine
+--   if null s
+--     then throwError "The string was empty!"
+--     else return $ length s
+-- :}
+--
+-- Prints result of the string length calculation.
+--
+-- >>> :{
+-- reportResult :: Either String Int -> IO ()
+-- reportResult (Right len) = putStrLn ("The length of the string is " ++ (show len))
+-- reportResult (Left e) = putStrLn ("Length calculation failed with error: " ++ (show e))
+-- :}
+--
+-- >>> :{
+-- main = do
+--   -- runExceptT removes the ExceptT wrapper
+--   r <- runExceptT calculateLength
+--   reportResult r
+-- :}

--- a/Control/Monad/Except.hs
+++ b/Control/Monad/Except.hs
@@ -139,12 +139,12 @@ import qualified Control.Monad.Trans.Except as Except
 -- the monad type of the combined monad, especially if we combine more
 -- monad transformers.
 --
--- >>> import Control.Monad.Except
--- >>> import Control.Monad.IO.Class (liftIO)
 -- >>> type LengthMonad = ExceptT String IO
 --
 -- Asks user for a non-empty string and returns its length.
 -- Throws an error if user enters an empty string.
+--
+-- >>> import Control.Monad.IO.Class (liftIO)
 --
 -- >>> :{
 -- calculateLength :: LengthMonad Int

--- a/Control/Monad/Reader.hs
+++ b/Control/Monad/Reader.hs
@@ -68,84 +68,92 @@ import Control.Monad.Trans.Reader (
     Reader, runReader, mapReader, withReader,
     ReaderT(ReaderT), runReaderT, mapReaderT, withReaderT)
 
-{- $simpleReaderExample
+-- $simpleReaderExample
+--
+-- In this example the @Reader@ monad provides access to variable bindings.
+-- Bindings are a @Map@ of integer variables.
+-- The variable @count@ contains number of variables in the bindings.
+-- You can see how to run a Reader monad and retrieve data from it
+-- with 'runReader', how to access the Reader data with 'ask' and 'asks'.
+--
+-- >>> import           Control.Monad.Reader
+-- >>> import           Data.Map (Map)
+-- >>> import qualified Data.Map as Map
+-- >>>
+-- >>> type Bindings = Map String Int
+--
+-- The selector function to use with 'asks'.
+-- Returns value of the variable with specified name.
+--
+-- >>> :{
+-- lookupVar :: String -> Bindings -> Int
+-- lookupVar name bindings = maybe 0 id (Map.lookup name bindings)
+-- :}
+--
+-- Checks if the "count" variable contains correct bindings size.
+--
+-- >>> :{
+-- calcIscountcorrect :: Reader Bindings Bool
+-- calcIscountcorrect = do
+--     count <- asks (lookupVar "count")
+--     bindings <- ask
+--     return (count == (Map.size bindings))
+-- :}
+--
+-- Returns True if the "count" variable contains correct bindings size.
+--
+-- >>> :{
+-- sampleBindings :: Bindings
+-- sampleBindings = Map.fromList [("count", 3), ("1", 1), ("b", 2)]
+-- :}
+--
+-- >>> runReader calcIscountcorrect sampleBindings
+-- True
 
-In this example the @Reader@ monad provides access to variable bindings.
-Bindings are a @Map@ of integer variables.
-The variable @count@ contains number of variables in the bindings.
-You can see how to run a Reader monad and retrieve data from it
-with 'runReader', how to access the Reader data with 'ask' and 'asks'.
+-- $localExample
+--
+-- Shows how to modify Reader content with 'local'.
+--
+-- >>> import Control.Monad.Reader
+--
+-- >>> :{
+-- calculateContentLen :: Reader String Int
+-- calculateContentLen = do
+--     content <- ask
+--     return (length content)
+-- :}
+--
+-- Calls calculateContentLen after adding a prefix to the Reader content.
+--
+-- >>> :{
+-- calculateModifiedContentLen :: Reader String Int
+-- calculateModifiedContentLen = local ("Prefix " ++) calculateContentLen
+-- :}
+--
+-- >>> runReader calculateContentLen "12345"
+-- 5
+--
+-- >>> runReader calculateModifiedContentLen "12345"
+-- 12
+--
 
->import           Control.Monad.Reader
->import           Data.Map (Map)
->import qualified Data.Map as Map
->
->type Bindings = Map String Int
->
->-- Returns True if the "count" variable contains correct bindings size.
->isCountCorrect :: Bindings -> Bool
->isCountCorrect bindings = runReader calc_isCountCorrect bindings
->
->-- The Reader monad, which implements this complicated check.
->calc_isCountCorrect :: Reader Bindings Bool
->calc_isCountCorrect = do
->    count <- asks (lookupVar "count")
->    bindings <- ask
->    return (count == (Map.size bindings))
->
->-- The selector function to use with 'asks'.
->-- Returns value of the variable with specified name.
->lookupVar :: String -> Bindings -> Int
->lookupVar name bindings = maybe 0 id (Map.lookup name bindings)
->
->sampleBindings :: Bindings
->sampleBindings = Map.fromList [("count", 3), ("1", 1), ("b", 2)]
->
->main :: IO ()
->main = do
->    putStr $ "Count is correct for bindings " ++ (show sampleBindings) ++ ": "
->    putStrLn $ show (isCountCorrect sampleBindings)
--}
-
-{- $localExample
-
-Shows how to modify Reader content with 'local'.
-
->import Control.Monad.Reader
->
->calculateContentLen :: Reader String Int
->calculateContentLen = do
->    content <- ask
->    return (length content);
->
->-- Calls calculateContentLen after adding a prefix to the Reader content.
->calculateModifiedContentLen :: Reader String Int
->calculateModifiedContentLen = local ("Prefix " ++) calculateContentLen
->
->main :: IO ()
->main = do
->    let s = "12345";
->    let modifiedLen = runReader calculateModifiedContentLen s
->    let len = runReader calculateContentLen s
->    putStrLn $ "Modified 's' length: " ++ (show modifiedLen)
->    putStrLn $ "Original 's' length: " ++ (show len)
--}
-
-{- $ReaderTExample
-
-Now you are thinking: 'Wow, what a great monad! I wish I could use
-Reader functionality in MyFavoriteComplexMonad!'. Don't worry.
-This can be easily done with the 'ReaderT' monad transformer.
-This example shows how to combine @ReaderT@ with the IO monad.
-
->import Control.Monad.Reader
->
->-- The Reader/IO combined monad, where Reader stores a string.
->printReaderContent :: ReaderT String IO ()
->printReaderContent = do
->    content <- ask
->    liftIO $ putStrLn ("The Reader Content: " ++ content)
->
->main :: IO ()
->main = runReaderT printReaderContent "Some Content"
--}
+-- $ReaderTExample
+--
+-- Now you are thinking: 'Wow, what a great monad! I wish I could use
+-- Reader functionality in MyFavoriteComplexMonad!'. Don't worry.
+-- This can be easily done with the 'ReaderT' monad transformer.
+-- This example shows how to combine @ReaderT@ with the IO monad.
+--
+-- >>> import Control.Monad.Reader
+--
+-- The Reader/IO combined monad, where Reader stores a string.
+--
+-- >>> :{
+-- printReaderContent :: ReaderT String IO ()
+-- printReaderContent = do
+--     content <- ask
+--     liftIO $ putStrLn ("The Reader Content: " ++ content)
+-- :}
+--
+-- >>> runReaderT printReaderContent "Some Content"
+-- The Reader Content: Some Content

--- a/Control/Monad/State/Class.hs
+++ b/Control/Monad/State/Class.hs
@@ -39,7 +39,7 @@ module Control.Monad.State.Class (
 import Control.Monad.Trans.Cont (ContT)
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Identity (IdentityT)
-import Control.Monad.Trans.Maybe (MaybeT) 
+import Control.Monad.Trans.Maybe (MaybeT)
 import Control.Monad.Trans.Reader (ReaderT)
 import qualified Control.Monad.Trans.RWS.Lazy as LazyRWS
 import qualified Control.Monad.Trans.RWS.Strict as StrictRWS
@@ -76,15 +76,15 @@ class Monad m => MonadState s m | m -> s where
 
 -- | Monadic state transformer.
 --
---      Maps an old state to a new state inside a state monad.
---      The old state is thrown away.
+-- Maps an old state to a new state inside a state monad.
+-- The old state is thrown away.
 --
--- >      Main> :t modify ((+1) :: Int -> Int)
--- >      modify (...) :: (MonadState Int a) => a ()
+-- >>> :t modify ((+1) :: Int -> Int)
+-- modify ((+1) :: Int -> Int) :: MonadState Int m => m ()
 --
---    This says that @modify (+1)@ acts over any
---    Monad that is a member of the @MonadState@ class,
---    with an @Int@ state.
+-- This says that @modify (+1)@ acts over any
+-- Monad that is a member of the @MonadState@ class,
+-- with an @Int@ state.
 modify :: MonadState s m => (s -> s) -> m ()
 modify f = state (\s -> ((), f s))
 

--- a/Control/Monad/State/Lazy.hs
+++ b/Control/Monad/State/Lazy.hs
@@ -51,26 +51,32 @@ import Control.Monad.Trans.State.Lazy
         (State, runState, evalState, execState, mapState, withState,
          StateT(StateT), runStateT, evalStateT, execStateT, mapStateT, withStateT)
 
--- ---------------------------------------------------------------------------
 -- $examples
+--
 -- A function to increment a counter.  Taken from the paper
 -- /Generalising Monads to Arrows/, John
 -- Hughes (<http://www.cse.chalmers.se/~rjmh/Papers/arrows.pdf>), November 1998:
 --
--- > tick :: State Int Int
--- > tick = do n <- get
--- >           put (n+1)
--- >           return n
+-- >>> :{
+-- tick :: State Int Int
+-- tick = do n <- get
+--           put (n+1)
+--           return n
+-- :}
 --
 -- Add one to the given number using the state monad:
 --
--- > plusOne :: Int -> Int
--- > plusOne n = execState tick n
+-- >>> :{
+-- plusOne :: Int -> Int
+-- plusOne n = execState tick n
+-- :}
 --
 -- A contrived addition example. Works only with positive numbers:
 --
--- > plus :: Int -> Int -> Int
--- > plus n x = execState (sequence $ replicate n tick) x
+-- >>> :{
+-- plus :: Int -> Int -> Int
+-- plus n x = execState (sequence $ replicate n tick) x
+-- :}
 --
 -- An example from /The Craft of Functional Programming/, Simon
 -- Thompson (<http://www.cs.kent.ac.uk/people/staff/sjt/>),
@@ -81,46 +87,52 @@ import Control.Monad.Trans.State.Lazy
 -- an as-yet-unvisited element we have to find a \'new\' number to match
 -- it with:\"
 --
--- > data Tree a = Nil | Node a (Tree a) (Tree a) deriving (Show, Eq)
--- > type Table a = [a]
+-- >>> data Tree a = Nil | Node a (Tree a) (Tree a) deriving (Show, Eq)
+-- >>> type Table a = [a]
 --
--- > numberTree :: Eq a => Tree a -> State (Table a) (Tree Int)
--- > numberTree Nil = return Nil
--- > numberTree (Node x t1 t2)
--- >        =  do num <- numberNode x
--- >              nt1 <- numberTree t1
--- >              nt2 <- numberTree t2
--- >              return (Node num nt1 nt2)
--- >     where
--- >     numberNode :: Eq a => a -> State (Table a) Int
--- >     numberNode x
--- >        = do table <- get
--- >             (newTable, newPos) <- return (nNode x table)
--- >             put newTable
--- >             return newPos
--- >     nNode::  (Eq a) => a -> Table a -> (Table a, Int)
--- >     nNode x table
--- >        = case (findIndexInList (== x) table) of
--- >          Nothing -> (table ++ [x], length table)
--- >          Just i  -> (table, i)
--- >     findIndexInList :: (a -> Bool) -> [a] -> Maybe Int
--- >     findIndexInList = findIndexInListHelp 0
--- >     findIndexInListHelp _ _ [] = Nothing
--- >     findIndexInListHelp count f (h:t)
--- >        = if (f h)
--- >          then Just count
--- >          else findIndexInListHelp (count+1) f t
+-- >>> :{
+-- numberTree :: Eq a => Tree a -> State (Table a) (Tree Int)
+-- numberTree Nil = return Nil
+-- numberTree (Node x t1 t2)
+--        =  do num <- numberNode x
+--              nt1 <- numberTree t1
+--              nt2 <- numberTree t2
+--              return (Node num nt1 nt2)
+--     where
+--     numberNode :: Eq a => a -> State (Table a) Int
+--     numberNode x
+--        = do table <- get
+--             (newTable, newPos) <- return (nNode x table)
+--             put newTable
+--             return newPos
+--     nNode::  (Eq a) => a -> Table a -> (Table a, Int)
+--     nNode x table
+--        = case (findIndexInList (== x) table) of
+--          Nothing -> (table ++ [x], length table)
+--          Just i  -> (table, i)
+--     findIndexInList :: (a -> Bool) -> [a] -> Maybe Int
+--     findIndexInList = findIndexInListHelp 0
+--     findIndexInListHelp _ _ [] = Nothing
+--     findIndexInListHelp count f (h:t)
+--        = if (f h)
+--          then Just count
+--          else findIndexInListHelp (count+1) f t
+-- :}
 --
 -- numTree applies numberTree with an initial state:
 --
--- > numTree :: (Eq a) => Tree a -> Tree Int
--- > numTree t = evalState (numberTree t) []
+-- >>> :{
+-- numTree :: (Eq a) => Tree a -> Tree Int
+-- numTree t = evalState (numberTree t) []
+-- :}
 --
--- > testTree = Node "Zero" (Node "One" (Node "Two" Nil Nil) (Node "One" (Node "Zero" Nil Nil) Nil)) Nil
--- > numTree testTree => Node 0 (Node 1 (Node 2 Nil Nil) (Node 1 (Node 0 Nil Nil) Nil)) Nil
+-- >>> numTree (Node "Zero" (Node "One" (Node "Two" Nil Nil) (Node "One" (Node "Zero" Nil Nil) Nil)) Nil)
+-- Node 0 (Node 1 (Node 2 Nil Nil) (Node 1 (Node 0 Nil Nil) Nil)) Nil
 --
 -- sumTree is a little helper function that does not use the State monad:
 --
--- > sumTree :: (Num a) => Tree a -> a
--- > sumTree Nil = 0
--- > sumTree (Node e t1 t2) = e + (sumTree t1) + (sumTree t2)
+-- >>> :{
+-- sumTree :: (Num a) => Tree a -> a
+-- sumTree Nil = 0
+-- sumTree (Node e t1 t2) = e + (sumTree t1) + (sumTree t2)
+-- :}

--- a/Control/Monad/State/Strict.hs
+++ b/Control/Monad/State/Strict.hs
@@ -51,26 +51,32 @@ import Control.Monad.Trans.State.Strict
         (State, runState, evalState, execState, mapState, withState,
          StateT(StateT), runStateT, evalStateT, execStateT, mapStateT, withStateT)
 
--- ---------------------------------------------------------------------------
 -- $examples
+--
 -- A function to increment a counter.  Taken from the paper
 -- /Generalising Monads to Arrows/, John
 -- Hughes (<http://www.math.chalmers.se/~rjmh/>), November 1998:
 --
--- > tick :: State Int Int
--- > tick = do n <- get
--- >           put (n+1)
--- >           return n
+-- >>> :{
+-- tick :: State Int Int
+-- tick = do n <- get
+--           put (n+1)
+--           return n
+-- :}
 --
 -- Add one to the given number using the state monad:
 --
--- > plusOne :: Int -> Int
--- > plusOne n = execState tick n
+-- >>> :{
+-- plusOne :: Int -> Int
+-- plusOne n = execState tick n
+-- :}
 --
 -- A contrived addition example. Works only with positive numbers:
 --
--- > plus :: Int -> Int -> Int
--- > plus n x = execState (sequence $ replicate n tick) x
+-- >>> :{
+-- plus :: Int -> Int -> Int
+-- plus n x = execState (sequence $ replicate n tick) x
+-- :}
 --
 -- An example from /The Craft of Functional Programming/, Simon
 -- Thompson (<http://www.cs.kent.ac.uk/people/staff/sjt/>),
@@ -81,46 +87,52 @@ import Control.Monad.Trans.State.Strict
 -- an as-yet-unvisited element we have to find a \'new\' number to match
 -- it with:\"
 --
--- > data Tree a = Nil | Node a (Tree a) (Tree a) deriving (Show, Eq)
--- > type Table a = [a]
+-- >>> data Tree a = Nil | Node a (Tree a) (Tree a) deriving (Show, Eq)
+-- >>> type Table a = [a]
 --
--- > numberTree :: Eq a => Tree a -> State (Table a) (Tree Int)
--- > numberTree Nil = return Nil
--- > numberTree (Node x t1 t2)
--- >        =  do num <- numberNode x
--- >              nt1 <- numberTree t1
--- >              nt2 <- numberTree t2
--- >              return (Node num nt1 nt2)
--- >     where
--- >     numberNode :: Eq a => a -> State (Table a) Int
--- >     numberNode x
--- >        = do table <- get
--- >             (newTable, newPos) <- return (nNode x table)
--- >             put newTable
--- >             return newPos
--- >     nNode::  (Eq a) => a -> Table a -> (Table a, Int)
--- >     nNode x table
--- >        = case (findIndexInList (== x) table) of
--- >          Nothing -> (table ++ [x], length table)
--- >          Just i  -> (table, i)
--- >     findIndexInList :: (a -> Bool) -> [a] -> Maybe Int
--- >     findIndexInList = findIndexInListHelp 0
--- >     findIndexInListHelp _ _ [] = Nothing
--- >     findIndexInListHelp count f (h:t)
--- >        = if (f h)
--- >          then Just count
--- >          else findIndexInListHelp (count+1) f t
+-- >>> :{
+-- numberTree :: Eq a => Tree a -> State (Table a) (Tree Int)
+-- numberTree Nil = return Nil
+-- numberTree (Node x t1 t2)
+--        =  do num <- numberNode x
+--              nt1 <- numberTree t1
+--              nt2 <- numberTree t2
+--              return (Node num nt1 nt2)
+--     where
+--     numberNode :: Eq a => a -> State (Table a) Int
+--     numberNode x
+--        = do table <- get
+--             (newTable, newPos) <- return (nNode x table)
+--             put newTable
+--             return newPos
+--     nNode::  (Eq a) => a -> Table a -> (Table a, Int)
+--     nNode x table
+--        = case (findIndexInList (== x) table) of
+--          Nothing -> (table ++ [x], length table)
+--          Just i  -> (table, i)
+--     findIndexInList :: (a -> Bool) -> [a] -> Maybe Int
+--     findIndexInList = findIndexInListHelp 0
+--     findIndexInListHelp _ _ [] = Nothing
+--     findIndexInListHelp count f (h:t)
+--        = if (f h)
+--          then Just count
+--          else findIndexInListHelp (count+1) f t
+-- :}
 --
 -- numTree applies numberTree with an initial state:
 --
--- > numTree :: (Eq a) => Tree a -> Tree Int
--- > numTree t = evalState (numberTree t) []
+-- >>> :{
+-- numTree :: (Eq a) => Tree a -> Tree Int
+-- numTree t = evalState (numberTree t) []
+-- :}
 --
--- > testTree = Node "Zero" (Node "One" (Node "Two" Nil Nil) (Node "One" (Node "Zero" Nil Nil) Nil)) Nil
--- > numTree testTree => Node 0 (Node 1 (Node 2 Nil Nil) (Node 1 (Node 0 Nil Nil) Nil)) Nil
+-- >>> numTree (Node "Zero" (Node "One" (Node "Two" Nil Nil) (Node "One" (Node "Zero" Nil Nil) Nil)) Nil)
+-- Node 0 (Node 1 (Node 2 Nil Nil) (Node 1 (Node 0 Nil Nil) Nil)) Nil
 --
 -- sumTree is a little helper function that does not use the State monad:
 --
--- > sumTree :: (Num a) => Tree a -> a
--- > sumTree Nil = 0
--- > sumTree (Node e t1 t2) = e + (sumTree t1) + (sumTree t2)
+-- >>> :{
+-- sumTree :: (Num a) => Tree a -> a
+-- sumTree Nil = 0
+-- sumTree (Node e t1 t2) = e + (sumTree t1) + (sumTree t2)
+-- :}

--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,5 @@ packages: ./mtl.cabal
 package mtl
   ghc-options: -Werror
 
--- This adds containers to the build plan, because it's required by the
--- doc tests.
+-- Add containers to the build plan. It is required by the doc tests.
 extra-packages: containers

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,7 @@ packages: ./mtl.cabal
 
 package mtl
   ghc-options: -Werror
+
+-- This adds containers to the build plan, because it's required by the
+-- doc tests.
+extra-packages: containers


### PR DESCRIPTION
This adds the setup required to run doc-testing using cabal-docspec, developed by @phadej.

This is the same setup that the the "kmettverse" uses (e.g. the [comonad](https://github.com/ekmett/comonad/blob/main/.github/workflows/haskell-ci.yml) package).

It also starts converting existing documentation to docspecs, i.e. the Control.Monad.Except module.