### PR TITLE
mtl-2.3.1 release prep

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,12 +1,13 @@
-2.3.1 -- Unreleased
+2.3.1 -- 2022-07-05
 -----
-* Add `modifyError` to `Control.Monad.Error.Class`, and re-export from
-  `Control.Monad.Except`.
+* Add `modifyError` to `Control.Monad.Error.Class`
+* Return re-export of `ExceptT` and related functions to `Control.Monad.Except`.
+* Add `label` function to `MonadCont`
 
 2.3 -- 2022-05-07
 ---
-* Add instances for `Control.Monad.Trans.Writer.CPS` and 
-  `Control.Monad.Trans.RWS.CPS` from `transformers` 0.5.6 and add 
+* Add instances for `Control.Monad.Trans.Writer.CPS` and
+  `Control.Monad.Trans.RWS.CPS` from `transformers` 0.5.6 and add
   `Control.Monad.Writer.CPS` and `Control.Monad.RWS.CPS`.
 * `Control.Monad.Cont` now re-exports `evalCont` and `evalContT`.
 * Add `tryError`, `withError`, `handleError`, and `mapError` to
@@ -14,7 +15,7 @@
 * Remove `Control.Monad.List` and `Control.Monad.Error`.
 * Remove instances of deprecated `ListT` and `ErrorT`.
 * Remove re-exports of `Error`.
-* Add instances for `Control.Monad.Trans.Accum` and 
+* Add instances for `Control.Monad.Trans.Accum` and
   `Control.Monad.Trans.Select`.
 * Require GHC 8.6 or higher, and `cabal-install` 3.0 or higher.
 * Require `transformers-0.5.6` or higher.

--- a/docs/Mtl-2.3.x-Migration.md
+++ b/docs/Mtl-2.3.x-Migration.md
@@ -1,0 +1,34 @@
+# Migrating to `mtl-2.3.x`
+
+In `mtl-2.3.x`, [re-exports were removed](https://github.com/haskell/mtl/pull/108) from the library in order to achieve PVP compliance, as well as disentangle some historical warts in its design. This was a breaking change that maintainers decided was in the `mtl`'s best interest due to the re-exports overlapping with `base`, as well as generally being confusing and outdated for modern GHC versions. While all changes were detailed in the changelog, navigating the removal of re-exports can be tricky. Below is a detailed review of what needs to be done to use the new `mtl`.
+
+## Removed re-exports
+
+The following `base`-specific re-exports were cut from many modules:
+
+- `Control.Monad`
+- `Control.Monad.Fix`
+- `Data.Monoid`
+
+In `mtl-2.3`, the following export was erroneously removed from `mtl`-specific modules:
+
+- `ExceptT` and related functions from `Control.Monad.Except`
+
+## What do I need to do?
+
+First, update your `*.cabal` file to point to the new `mtl-2.3.1` release (currently on Hackage), or add the following to your `cabal.project`:
+
+
+```
+packages: .
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell/mtl
+  tag: 2.3.1
+
+allow-newer:
+  *:mtl
+```
+
+Now, if upon recompile you see anything to the effect that particular functions from any of the above re-exports are missing, then you'll need to import the modules explicitly in order to expose the functions.

--- a/mtl.cabal
+++ b/mtl.cabal
@@ -1,11 +1,11 @@
 cabal-version: 3.0
 name:          mtl
-version:       2.3
+version:       2.3.1
 license:       BSD-3-Clause
 license-file:  LICENSE
 author:        Andy Gill
-maintainer:    chessai <chessai1996@gmail.com>, 
-               Emily Pillmore <emilypi@cohomolo.gy>, 
+maintainer:    chessai <chessai1996@gmail.com>,
+               Emily Pillmore <emilypi@cohomolo.gy>,
                Koz Ross <koz.ross@retro-freedom.nz>
 category:      Control
 synopsis:      Monad classes for transformers, using functional dependencies
@@ -18,7 +18,7 @@ description:
 
 build-type: Simple
 
-extra-source-files: 
+extra-source-files:
   CHANGELOG.markdown
   README.markdown
 
@@ -54,15 +54,14 @@ Library
     Control.Monad.Writer.Strict
     Control.Monad.Accum
     Control.Monad.Select
-  
-  build-depends: 
+
+  build-depends:
     , base >=4.12 && < 5
     , transformers >= 0.5.6 && <0.7
 
-  ghc-options: 
+  ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints
     -Wmissing-export-lists
 
   default-language: Haskell2010
-


### PR DESCRIPTION
This PR adds the following: 

- Bumps `mtl.cabal` to 2.3.1
- Updates the changelog with release notes
- Adds a migration guide for `mtl-2.3.x`, addressing #119 