### PR TITLE
Add 9.4 support, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ghc: ['8.6', '8.8', '8.10', '9.0', '9.2']
+        ghc: ['8.6', '8.8', '8.10', '9.0', '9.2', '9.4.1']
     steps:
       - name: Checkout base repo
         uses: actions/checkout@v2.3.5

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,7 @@ cabal.sandbox.config
 *.hp
 *.eventlog
 .stack-work/
-cabal.project.local
-cabal.project.local~
+cabal.project.local*
 .HTF/
 .ghc.environment.*
 .nvimrc

--- a/mtl.cabal
+++ b/mtl.cabal
@@ -22,7 +22,7 @@ extra-source-files:
   CHANGELOG.markdown
   README.markdown
 
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.2
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.1
 
 source-repository head
   type: git


### PR DESCRIPTION
Since [GHC 9.4 is out now](https://www.haskell.org/ghc/download_ghc_9_4_1.html), I figured I'd update our CI to test with it.