### PR TITLE
fix tag in mtl-2.3.x migration guide

### DIFF
--- a/docs/Mtl-2.3.x-Migration.md
+++ b/docs/Mtl-2.3.x-Migration.md
@@ -25,7 +25,7 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/haskell/mtl
-  tag: 2.3.1
+  tag: v2.3.1
 
 allow-newer:
   *:mtl


### PR DESCRIPTION
Since mtl-2.3.1 has not yet been tagged, I cannot be sure that this fix is correct... . However, going by historical precedent (all other tags start with a `v`, including `v2.3.1-rc1`) I suspect that this was a typo.