### PR TITLE
feat(Control.Monad.Writer.CPS): re export runWriterT

### DIFF
--- a/Control/Monad/Writer/CPS.hs
+++ b/Control/Monad/Writer/CPS.hs
@@ -33,6 +33,7 @@ module Control.Monad.Writer.CPS (
     mapWriter,
     -- * The WriterT monad transformer
     WriterT,
+    runWriterT,
     execWriterT,
     mapWriterT,
     module Control.Monad.Trans,
@@ -42,4 +43,4 @@ import qualified Control.Monad.Writer.Class as MonadWriter
 import Control.Monad.Trans
 import Control.Monad.Trans.Writer.CPS (
         Writer, runWriter, execWriter, mapWriter,
-        WriterT, execWriterT, mapWriterT)
+        WriterT, runWriterT, execWriterT, mapWriterT)


### PR DESCRIPTION
Why is this modification necessary?
Writer.Strict, the transformers exposes the internal field of WriterT, which is runWriterT. However, for Control.Monad.Trans.Writer.CPS, it does not expose the internal fields and is a separate function, so it needs to be added to the import/export list.