### PR TITLE
 Added `liftMaybe` for lifting Maybe into MonadError

### DIFF
--- a/Control/Monad/Error/Class.hs
+++ b/Control/Monad/Error/Class.hs
@@ -45,6 +45,7 @@ The Error monad (also called the Exception monad).
 module Control.Monad.Error.Class (
     MonadError(..),
     liftEither,
+    liftMaybe,
     tryError,
     withError,
     handleError,
@@ -74,7 +75,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Exception (IOException, catch, ioError)
 import Control.Monad (Monad)
 import Data.Monoid (Monoid)
-import Prelude (Either (Left, Right), Maybe (Nothing), either, flip, (.), IO, pure, (<$>), (>>=))
+import Prelude (Either (Left, Right), Maybe (Nothing), either, maybe, flip, (.), IO, pure, (<$>), (>>=))
 
 {- |
 The strategy of combining computations that can throw exceptions
@@ -121,6 +122,16 @@ where @action1@ returns an 'Either' to represent errors.
 -}
 liftEither :: MonadError e m => Either e a -> m a
 liftEither = either throwError pure
+
+{- |
+Lifts a @'Maybe' a@ into any @'MonadError' e@, using @e@ as the error if the 'Maybe' is 'Nothing'.
+
+> do { val <- liftMaybe e =<< action1; action2 }
+
+where @action1@ returns an 'Maybe'.
+-}
+liftMaybe :: MonadError e m => e -> Maybe a -> m a
+liftMaybe e = maybe (throwError e) pure
 
 instance MonadError IOException IO where
     throwError = ioError

--- a/Control/Monad/Error/Class.hs
+++ b/Control/Monad/Error/Class.hs
@@ -124,11 +124,11 @@ liftEither :: MonadError e m => Either e a -> m a
 liftEither = either throwError pure
 
 {- |
-Lifts a @'Maybe' a@ into any @'MonadError' e@, using @e@ as the error if the 'Maybe' is 'Nothing'.
+Lifts a @'Maybe'@ into any @'MonadError' e@, using a supplied @e@ as the error if the 'Maybe' is 'Nothing'.
 
 > do { val <- liftMaybe e =<< action1; action2 }
 
-where @action1@ returns an 'Maybe'.
+where @action1@ returns a 'Maybe'.
 -}
 liftMaybe :: MonadError e m => e -> Maybe a -> m a
 liftMaybe e = maybe (throwError e) pure


### PR DESCRIPTION
On #37 it was discussed the existence of `liftMaybe`:

        I think `lift` is fine, but would also like `liftMaybe`.

_Originally posted by @ocharles in https://github.com/haskell/mtl/issues/37#issuecomment-325640686_
      
This PR adds `liftMaybe`, also called `note` in some custom preludes like [Universum](https://hackage.haskell.org/package/universum-1.8.1/docs/Universum-Exception.html#v:note) and [Protolude](https://hackage.haskell.org/package/protolude-0.3.2/docs/Protolude.html#v:note)

On Universum, they suggest using `maybeToRight`, which involves `liftMaybe e = liftEither . maybeToRight e`. Personally, I'm not a big fan of such boilerplate.

---

Lifts a `Maybe` into any `MonadError e`, using a supplied `e` as the error if the `Maybe` is `Nothing`.

```haskell
do { val <- liftMaybe e =<< action1; action2 }
```

where `action1` returns a `Maybe`.