### PR TITLE
Bypass Coercible Type for Deriving Monad* Classes of New Transformers Composed of Transformers

### DIFF
--- a/Control/Monad/Bypass.hs
+++ b/Control/Monad/Bypass.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingVia #-}
+module Control.Monad.Bypass
+  ( Bypass
+  ) where
+
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Writer
+import Data.Kind (Type)
+
+type Bypass :: ((Type -> Type) -> Type -> Type) -> (Type -> Type) -> Type -> Type
+newtype Bypass t m a = Bypass (t m a) deriving (Functor, Applicative, Monad, MonadTrans)
+
+instance MonadReader r m => MonadReader r (Bypass (ReaderT r') m) where
+  ask = lift ask
+  local f (Bypass (ReaderT x)) = Bypass . ReaderT $ local f . x
+  reader = lift . reader
+
+instance (MonadWriter w m, Monoid w') => MonadWriter w (Bypass (WriterT w') m) where
+  writer = lift . writer
+  tell = lift . tell
+  listen (Bypass (WriterT x)) = Bypass $ WriterT $ (\((a, w'), w) -> ((a, w), w')) <$> listen x
+  pass (Bypass (WriterT x)) = Bypass $ WriterT $ (\((a,f),w') -> pass $ return ((a,w'),f)) =<< x
+
+instance MonadState s m => MonadState s (Bypass (StateT s') m) where
+  get = lift get
+  put = lift . put
+  state = lift . state
+
+newtype ExampleT m a = ExampleT (ReaderT Int m a) deriving (Functor, Applicative, Monad)
+
+deriving via Bypass (ReaderT Int) m instance MonadReader r m => MonadReader r (ExampleT m)
+

--- a/mtl.cabal
+++ b/mtl.cabal
@@ -32,6 +32,7 @@ Library
   exposed-modules:
     Control.Monad.Cont
     Control.Monad.Cont.Class
+    Control.Monad.Bypass
     Control.Monad.Error.Class
     Control.Monad.Except
     Control.Monad.Identity


### PR DESCRIPTION
When creating a new transformer it is often composed of other transformers. The transformers that it is composed of usually have specific purposes that are unrelated to the more general uses of the Monad* classes and typically you still want to define the Monad* instances for the underlying monad.

My real world use case is the

```haskell
newtype FileT w m a = FileT (ReaderT Handle m a)
```

where I still want to have MonadReader but not for reading Handle but rather the r for m `instance MonadReader r m => MonadReader r (FileT w m)`

This is a bit annoying for this case but even more so for transformers wrapping RWS. In just the ReaderT  case the following must be defined

```haskell
instance MonadReader r m => MonadReader r (FileT w m) where
  local f (FileT (ReaderT g)) = FileT . ReaderT $ local f . g 
  reader = lift . reader
```

DerivingVia seems to be a better option for this by using `Bypass`

```haskell
deriving via ByPass (ReaderT Handle) m instance MonadReader r m => MonadReader r (FileT w m)
```

There could probably a more succinct way to write the derivation but this is what I have so far.