### PR TITLE
Do not use quantified constraint in liftCallCC for transformers >= 0.6

### DIFF
--- a/Control/Monad/Cont/Class.hs
+++ b/Control/Monad/Cont/Class.hs
@@ -211,6 +211,10 @@ label_ = callCC $ return . fix
 -- @since 2.3.1
 liftCallCC :: 
   forall (t :: (Type -> Type) -> Type -> Type) (m :: Type -> Type) (a :: Type) (b :: Type) . 
-  (MonadTrans t, Monad m, forall (m' :: Type -> Type) . Monad m' => Monad (t m')) => 
+  (MonadTrans t, Monad m
+#if !MIN_VERSION_transformers(0,6,0) || defined(__MHS__)
+  , forall (m' :: Type -> Type) . Monad m' => Monad (t m')
+#endif
+  ) =>
   CallCC m (t m a) b -> CallCC (t m) a b
 liftCallCC f g = join . lift . f $ \exit -> pure $ g (lift . exit . pure)


### PR DESCRIPTION
Fixes #138.

Tested locally with GHC 9.0.2 and transformers-0.6.0.0.  Doesn't build without this change and does build with this change.